### PR TITLE
Change company transformation to match those for articles and images.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ target
 .idea
 buildurl.txt
 buildnum.txt
+/bin/
+/.classpath
+/.project
+/.settings/

--- a/src/main/java/com/ft/methodearticlemapper/transformation/MethodeBodyTransformationXMLEventHandlerRegistry.java
+++ b/src/main/java/com/ft/methodearticlemapper/transformation/MethodeBodyTransformationXMLEventHandlerRegistry.java
@@ -17,7 +17,7 @@ public class MethodeBodyTransformationXMLEventHandlerRegistry extends XMLEventHa
         registerCharactersEventHandler(new RetainXMLEventHandler());
         registerEntityReferenceEventHandler(new PlainTextHtmlEntityReferenceEventHandler());
         // want to be sure to keep the wrapping node
-        registerStartAndEndElementEventHandler(new RetainXMLEventHandler(), "body", "ft-concept");
+        registerStartAndEndElementEventHandler(new RetainXMLEventHandler(), "body", "concept");
         
         //rich content
         InlineImageXmlEventHandler inlineImageXmlEventHandler = new InlineImageXmlEventHandler();

--- a/src/test/java/com/ft/methodearticlemapper/BodyProcessingStepDefs.java
+++ b/src/test/java/com/ft/methodearticlemapper/BodyProcessingStepDefs.java
@@ -32,6 +32,8 @@ import org.apache.commons.lang.RandomStringUtils;
 import org.codehaus.stax2.ri.evt.EntityReferenceEventImpl;
 import org.codehaus.stax2.ri.evt.StartElementEventImpl;
 import org.custommonkey.xmlunit.Diff;
+import org.custommonkey.xmlunit.ElementNameAndTextQualifier;
+import org.custommonkey.xmlunit.XMLAssert;
 
 import com.ft.bodyprocessing.richcontent.ConvertParameters;
 import com.ft.bodyprocessing.richcontent.VideoMatcher;
@@ -334,7 +336,10 @@ public class BodyProcessingStepDefs {
     @When("^it is transformed, (.+) becomes (.+)$")
     public void the_before_becomes_after(String before, String after) throws Throwable {
         transformedBodyText = bodyTransformer.transform(wrapped(before), TRANSACTION_ID);
-        assertThat("before and after do not match", transformedBodyText, equalTo(wrapped(after)));
+        
+        Diff diff = new Diff(wrapped(after), transformedBodyText);
+        diff.overrideElementQualifier(new ElementNameAndTextQualifier());
+        XMLAssert.assertXMLEqual("transformed body does not match expected text", diff, true);
     }
 
     private String wrapped(String bodyMarkUp) {

--- a/src/test/java/com/ft/methodearticlemapper/transformation/TearSheetLinksTransformerTest.java
+++ b/src/test/java/com/ft/methodearticlemapper/transformation/TearSheetLinksTransformerTest.java
@@ -48,7 +48,8 @@ public class TearSheetLinksTransformerTest {
 	private final static String TME_AUTHORITY="http://api.ft.com/system/FT-TME";
 	private static final String TME_ID_1 = "tmeid1";
 	private static final String TME_ID_2 = "tmeid2";
-	private static final String API_URL2 ="http://api.ft.com/organisations/"+ UUID.randomUUID().toString();
+	private static final String ORG_ID = UUID.randomUUID().toString();
+	private static final String API_URL2 ="http://api.ft.com/organisations/"+ ORG_ID;
 	
 	private static final String BODY_1 ="<body> <p>Some text</p></body>";
 	
@@ -112,7 +113,7 @@ public class TearSheetLinksTransformerTest {
 	}
 	
 	@Test
-	public void shouldTransformCompnyIfCompanyTMEIdIsConcorded() throws Exception {
+	public void shouldTransformCompanyIfCompanyTMEIdIsConcorded() throws Exception {
 		doc = db.parse(new InputSource(new StringReader(BODY_3)));
 		nodes = getNodeList(doc);
 		String queryUrl = CONCORDANCE_URL + TME_ID_2;
@@ -121,9 +122,13 @@ public class TearSheetLinksTransformerTest {
 		String actual = serializeDocument(doc);
 
 		String expectedBody = "<body>" + "<p>Some text</p>"
-				+ "<p><ft-concept type=\"http://www.ft.com/ontology/company/PublicCompany\" url=\"" + API_URL2
-				+ "\">concorded company name</ft-concept></p>" + "</body>";
-		assertThat(actual, equalTo(expectedBody));
+				+ "<p><concept type=\"http://www.ft.com/ontology/company/PublicCompany\" id=\"" + ORG_ID
+				+ "\">concorded company name</concept></p>" + "</body>";
+//		assertThat(actual, equalTo(expectedBody));
+
+        Diff diff = new Diff(expectedBody, actual);
+        diff.overrideElementQualifier(new ElementNameAndTextQualifier());
+        XMLAssert.assertXMLEqual(diff, true);
 	}	
 	
 	
@@ -138,8 +143,8 @@ public class TearSheetLinksTransformerTest {
 
 		String expectedBody = "<body>" + "<p>Some text</p>"
 				+"<p><company CompositeId=\"tmeid1\" DICoSEDOL=\"2297907\"> not concorded company name</company></p>"
-				+ "<p><ft-concept type=\"http://www.ft.com/ontology/company/PublicCompany\" url=\"" + API_URL2
-				+ "\">concorded company name</ft-concept></p>" + "</body>";
+				+ "<p><concept type=\"http://www.ft.com/ontology/company/PublicCompany\" id=\"" + ORG_ID
+				+ "\">concorded company name</concept></p>" + "</body>";
 
 		Diff diff = new Diff(expectedBody, actual);
 		diff.overrideElementQualifier(new ElementNameAndTextQualifier());

--- a/src/test/java/com/ft/methodearticlemapper/transformation/TearSheetLinksTransformerTest.java
+++ b/src/test/java/com/ft/methodearticlemapper/transformation/TearSheetLinksTransformerTest.java
@@ -43,147 +43,145 @@ import com.sun.jersey.api.client.Client;
 import com.sun.jersey.api.client.WebResource;
 
 public class TearSheetLinksTransformerTest {
-	private static final URI CONCORDANCE_API = URI.create("http://localhost/concordances");
-	private static final URI CONCORDANCE_URL = URI.create("http://localhost/concordances?authority=http%3A%2F%2Fapi.ft.com%2Fsystem%2FFT-TME&identifierValue=");
-	private final static String TME_AUTHORITY="http://api.ft.com/system/FT-TME";
-	private static final String TME_ID_1 = "tmeid1";
-	private static final String TME_ID_2 = "tmeid2";
-	private static final String ORG_ID = UUID.randomUUID().toString();
-	private static final String API_URL2 ="http://api.ft.com/organisations/"+ ORG_ID;
-	
-	private static final String BODY_1 ="<body> <p>Some text</p></body>";
-	
-	private static final String BODY_2 = "<body>" 
-	+ "<p>Some text</p>"
-		      + "<p><company  DICoSEDOL=\"2297907\" CompositeId=\"" + TME_ID_1 +"\"  >not concorded company name</company></p>"
-		      + "</body>";
-	private static final String BODY_3 = "<body>" 
-			+ "<p>Some text</p>"
-		      + "<p><company  DICoSEDOL=\"2297907\" CompositeId=\"" + TME_ID_2 +"\" >concorded company name</company></p>"
-		      + "</body>";
-	private static final String BODY_4= "<body>" 
-	+ "<p>Some text</p>"
-		      + "<p><company  DICoSEDOL=\"2297907\" CompositeId=\"" + TME_ID_1 +"\"  > not concorded company name</company></p>"
-		      + "<p><company  DICoSEDOL=\"2297907\" CompositeId=\"" + TME_ID_2 +"\"  >concorded company name</company></p>"
-		      + "</body>";
-	
+  private static final URI CONCORDANCE_API = URI.create("http://localhost/concordances");
+  private static final URI CONCORDANCE_URL = URI.create(
+      "http://localhost/concordances?authority=http%3A%2F%2Fapi.ft.com%2Fsystem%2FFT-TME&identifierValue=");
+  private final static String TME_AUTHORITY = "http://api.ft.com/system/FT-TME";
+  private static final String TME_ID_1 = "tmeid1";
+  private static final String TME_ID_2 = "tmeid2";
+  private static final String ORG_ID = UUID.randomUUID().toString();
+  private static final String API_URL2 = "http://api.ft.com/organisations/" + ORG_ID;
 
-	private Document doc;
-	private NodeList nodes;
-	private DocumentBuilder db;
-	private TearSheetLinksTransformer toTest;
-	private Client client = mock(Client.class);
-    private Identifier identifier = new Identifier(TME_AUTHORITY, TME_ID_2);
-    private ConceptView concept= new ConceptView(API_URL2 , API_URL2 );
-    private Concordances concordances;
-	
-	@Before
-	  public void setUp() throws Exception {
-		toTest= new TearSheetLinksTransformer(client, CONCORDANCE_API);
-	    DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-	    db = dbf.newDocumentBuilder();
-	    
-        Concordance concordance = new Concordance(concept, identifier);
-        concordances = new Concordances(Arrays.asList(concordance));  
-	  
-	  }
-	
-	@Test
-	public void shouldNotChangeBodyIfNoCompanyTags() throws Exception{
-		doc = db.parse(new InputSource(new StringReader(BODY_1)));	
-        nodes=getNodeList(doc);
-		toTest.handle(doc, nodes);
-		String actual = serializeDocument(doc);
-		assertThat(actual, equalTo(BODY_1));
-		
-		verifyZeroInteractions(client);
-	}
-		
-	@Test
-	public void shouldNotChangeBodyIfCompanyTMEIdNotConcorded() throws Exception{
-		doc = db.parse(new InputSource(new StringReader(BODY_2)));
-		nodes=getNodeList(doc);
-        String queryUrl=CONCORDANCE_URL+TME_ID_1;
-		mockConcordanceQueryResponse(queryUrl, null);	
-		toTest.handle(doc, nodes);
-		String actual = serializeDocument(doc);
-		Diff diff = new Diff(BODY_2, actual);
-		diff.overrideElementQualifier(new ElementNameAndTextQualifier());
-		XMLAssert.assertXMLEqual(diff, true);
-	}
-	
-	@Test
-	public void shouldTransformCompanyIfCompanyTMEIdIsConcorded() throws Exception {
-		doc = db.parse(new InputSource(new StringReader(BODY_3)));
-		nodes = getNodeList(doc);
-		String queryUrl = CONCORDANCE_URL + TME_ID_2;
-		mockConcordanceQueryResponse(queryUrl, concordances);
-		toTest.handle(doc, nodes);
-		String actual = serializeDocument(doc);
+  private static final String BODY_1 = "<body> <p>Some text</p></body>";
 
-		String expectedBody = "<body>" + "<p>Some text</p>"
-				+ "<p><concept type=\"http://www.ft.com/ontology/company/PublicCompany\" id=\"" + ORG_ID
-				+ "\">concorded company name</concept></p>" + "</body>";
-//		assertThat(actual, equalTo(expectedBody));
+  private static final String BODY_2 =
+      "<body>" + "<p>Some text</p>" + "<p><company  DICoSEDOL=\"2297907\" CompositeId=\"" + TME_ID_1
+          + "\"  >not concorded company name</company></p>" + "</body>";
+  private static final String BODY_3 =
+      "<body>" + "<p>Some text</p>" + "<p><company  DICoSEDOL=\"2297907\" CompositeId=\"" + TME_ID_2
+          + "\" >concorded company name</company></p>" + "</body>";
+  private static final String BODY_4 =
+      "<body>" + "<p>Some text</p>" + "<p><company  DICoSEDOL=\"2297907\" CompositeId=\"" + TME_ID_1
+          + "\"  > not concorded company name</company></p>"
+          + "<p><company  DICoSEDOL=\"2297907\" CompositeId=\"" + TME_ID_2
+          + "\"  >concorded company name</company></p>" + "</body>";
 
-        Diff diff = new Diff(expectedBody, actual);
-        diff.overrideElementQualifier(new ElementNameAndTextQualifier());
-        XMLAssert.assertXMLEqual(diff, true);
-	}	
-	
-	
-	@Test
-	public void shouldTransformMultipleCompanies() throws Exception {
-		doc = db.parse(new InputSource(new StringReader(BODY_4)));
-		nodes = getNodeList(doc);
-		String queryUrl1 = CONCORDANCE_URL + TME_ID_2+"&identifierValue="+TME_ID_1;
-		mockConcordanceQueryResponse(queryUrl1, concordances);
-		toTest.handle(doc, nodes);
-		String actual = serializeDocument(doc);
 
-		String expectedBody = "<body>" + "<p>Some text</p>"
-				+"<p><company CompositeId=\"tmeid1\" DICoSEDOL=\"2297907\"> not concorded company name</company></p>"
-				+ "<p><concept type=\"http://www.ft.com/ontology/company/PublicCompany\" id=\"" + ORG_ID
-				+ "\">concorded company name</concept></p>" + "</body>";
+  private Document doc;
+  private NodeList nodes;
+  private DocumentBuilder db;
+  private TearSheetLinksTransformer toTest;
+  private Client client = mock(Client.class);
+  private Identifier identifier = new Identifier(TME_AUTHORITY, TME_ID_2);
+  private ConceptView concept = new ConceptView(API_URL2, API_URL2);
+  private Concordances concordances;
 
-		Diff diff = new Diff(expectedBody, actual);
-		diff.overrideElementQualifier(new ElementNameAndTextQualifier());
-		XMLAssert.assertXMLEqual(diff, true);
-	}	
-	
-	
-	private NodeList  getNodeList(Document doc) throws Exception{
-		 XPathFactory xpf = XPathFactory.newInstance();
-		 XPath xp = xpf.newXPath();
-		return nodes = (NodeList)xp.evaluate("//company", doc, XPathConstants.NODESET);	
-	}
-			
-	private String serializeDocument(Document document) {
-	      DOMSource domSource = new DOMSource(document);
-	      StringWriter writer = new StringWriter();
-	      StreamResult result = new StreamResult(writer);
+  @Before
+  public void setUp() throws Exception {
+    toTest = new TearSheetLinksTransformer(client, CONCORDANCE_API);
+    DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+    db = dbf.newDocumentBuilder();
 
-	      TransformerFactory tf = TransformerFactory.newInstance();
-	      try {
-	          Transformer transformer = tf.newTransformer();
-	          transformer.setOutputProperty("omit-xml-declaration", "yes");
-	          transformer.setOutputProperty("standalone", "yes");
-	          transformer.transform(domSource, result);
-	          writer.flush();
-	          String body = writer.toString();
-	          return body;
-	      } catch (TransformerException e) {
-	          throw new BodyProcessingException(e);
-	      }
-	  }
-	
-	
-	 private void mockConcordanceQueryResponse(String queryUrl, Concordances response) {
-		    WebResource resource = mock(WebResource.class);
-		    WebResource.Builder builder=mock(WebResource.Builder.class);
-		    when(client.resource(URI.create(queryUrl))).thenReturn(resource);
-		    when(resource.header(anyString(), anyObject())).thenReturn(builder);
-		    when(builder.get(Concordances.class)).thenReturn(response);
-		  }
+    Concordance concordance = new Concordance(concept, identifier);
+    concordances = new Concordances(Arrays.asList(concordance));
+
+  }
+
+  @Test
+  public void shouldNotChangeBodyIfNoCompanyTags() throws Exception {
+    doc = db.parse(new InputSource(new StringReader(BODY_1)));
+    nodes = getNodeList(doc);
+    toTest.handle(doc, nodes);
+    String actual = serializeDocument(doc);
+    assertThat(actual, equalTo(BODY_1));
+
+    verifyZeroInteractions(client);
+  }
+
+  @Test
+  public void shouldNotChangeBodyIfCompanyTMEIdNotConcorded() throws Exception {
+    doc = db.parse(new InputSource(new StringReader(BODY_2)));
+    nodes = getNodeList(doc);
+    String queryUrl = CONCORDANCE_URL + TME_ID_1;
+    mockConcordanceQueryResponse(queryUrl, null);
+    toTest.handle(doc, nodes);
+    String actual = serializeDocument(doc);
+    Diff diff = new Diff(BODY_2, actual);
+    diff.overrideElementQualifier(new ElementNameAndTextQualifier());
+    XMLAssert.assertXMLEqual(diff, true);
+  }
+
+  @Test
+  public void shouldTransformCompanyIfCompanyTMEIdIsConcorded() throws Exception {
+    doc = db.parse(new InputSource(new StringReader(BODY_3)));
+    nodes = getNodeList(doc);
+    String queryUrl = CONCORDANCE_URL + TME_ID_2;
+    mockConcordanceQueryResponse(queryUrl, concordances);
+    toTest.handle(doc, nodes);
+    String actual = serializeDocument(doc);
+
+    String expectedBody = "<body>" + "<p>Some text</p>"
+        + "<p><concept type=\"http://www.ft.com/ontology/company/PublicCompany\" id=\"" + ORG_ID
+        + "\">concorded company name</concept></p>" + "</body>";
+
+    Diff diff = new Diff(expectedBody, actual);
+    diff.overrideElementQualifier(new ElementNameAndTextQualifier());
+    XMLAssert.assertXMLEqual(diff, true);
+  }
+
+
+  @Test
+  public void shouldTransformMultipleCompanies() throws Exception {
+    doc = db.parse(new InputSource(new StringReader(BODY_4)));
+    nodes = getNodeList(doc);
+    String queryUrl1 = CONCORDANCE_URL + TME_ID_2 + "&identifierValue=" + TME_ID_1;
+    mockConcordanceQueryResponse(queryUrl1, concordances);
+    toTest.handle(doc, nodes);
+    String actual = serializeDocument(doc);
+
+    String expectedBody = "<body>" + "<p>Some text</p>"
+        + "<p><company CompositeId=\"tmeid1\" DICoSEDOL=\"2297907\"> not concorded company name</company></p>"
+        + "<p><concept type=\"http://www.ft.com/ontology/company/PublicCompany\" id=\"" + ORG_ID
+        + "\">concorded company name</concept></p>" + "</body>";
+
+    Diff diff = new Diff(expectedBody, actual);
+    diff.overrideElementQualifier(new ElementNameAndTextQualifier());
+    XMLAssert.assertXMLEqual(diff, true);
+  }
+
+
+  private NodeList getNodeList(Document doc) throws Exception {
+    XPathFactory xpf = XPathFactory.newInstance();
+    XPath xp = xpf.newXPath();
+    return nodes = (NodeList) xp.evaluate("//company", doc, XPathConstants.NODESET);
+  }
+
+  private String serializeDocument(Document document) {
+    DOMSource domSource = new DOMSource(document);
+    StringWriter writer = new StringWriter();
+    StreamResult result = new StreamResult(writer);
+
+    TransformerFactory tf = TransformerFactory.newInstance();
+    try {
+      Transformer transformer = tf.newTransformer();
+      transformer.setOutputProperty("omit-xml-declaration", "yes");
+      transformer.setOutputProperty("standalone", "yes");
+      transformer.transform(domSource, result);
+      writer.flush();
+      String body = writer.toString();
+      return body;
+    } catch (TransformerException e) {
+      throw new BodyProcessingException(e);
+    }
+  }
+
+
+  private void mockConcordanceQueryResponse(String queryUrl, Concordances response) {
+    WebResource resource = mock(WebResource.class);
+    WebResource.Builder builder = mock(WebResource.Builder.class);
+    when(client.resource(URI.create(queryUrl))).thenReturn(resource);
+    when(resource.header(anyString(), anyObject())).thenReturn(builder);
+    when(builder.get(Concordances.class)).thenReturn(response);
+  }
 
 }

--- a/src/test/resources/com/ft/methodearticlemapper/bodyProcessingCompanyTag.feature
+++ b/src/test/resources/com/ft/methodearticlemapper/bodyProcessingCompanyTag.feature
@@ -8,7 +8,7 @@ Feature: Body processing Company Tags
   Examples:
     | before                                                         | after                                                         |
     # Text within the a tag is preserved:
-    | <p><company DICoName="Citigroup Inc" DICoFTMWTickercode="us:C"  DICoSEDOL="2297907"  DICoTickerSymbol="C" DICoTickerExchangeCode="" CompositeId="TnN0ZWluX09OX0ZvcnR1bmVDb21wYW55X0M=-T04=">Citigroup</company> has been picked to safeguard $230bn worth of securities.</p> | <p><ft-concept type="http://www.ft.com/ontology/company/PublicCompany" url="http://api.ft.com/organisations/704a3225-9b5c-3b4f-93c7-8e6a6993bfb0">Citigroup</ft-concept> has been picked to safeguard $230bn worth of securities.</p>               |
+    | <p><company DICoName="Citigroup Inc" DICoFTMWTickercode="us:C"  DICoSEDOL="2297907"  DICoTickerSymbol="C" DICoTickerExchangeCode="" CompositeId="TnN0ZWluX09OX0ZvcnR1bmVDb21wYW55X0M=-T04=">Citigroup</company> has been picked to safeguard $230bn worth of securities.</p> | <p><concept type="http://www.ft.com/ontology/company/PublicCompany" id="704a3225-9b5c-3b4f-93c7-8e6a6993bfb0">Citigroup</concept> has been picked to safeguard $230bn worth of securities.</p>               |
    
   Scenario Outline: Company tags are stripped for missing Composite ids
     Given the Methode body has <tagname> the transformer will STRIP ELEMENT AND LEAVE CONTENT BY DEFAULT
@@ -17,8 +17,8 @@ Feature: Body processing Company Tags
     | tagname  | html                                           |
     | company  | <p><company DICoName="Citigroup Inc" DICoFTMWTickercode="us:C"  DICoSEDOL="2297907"  DICoTickerSymbol="C" DICoTickerExchangeCode=">Citigroup</company></p>|
     
-     Scenario Outline: Company tags are stripped for un-concorded Composite ids
-     Given the Methode body has <tagname> the transformer will STRIP ELEMENT AND LEAVE CONTENT BY DEFAULT
+  Scenario Outline: Company tags are stripped for un-concorded Composite ids
+    Given the Methode body has <tagname> the transformer will STRIP ELEMENT AND LEAVE CONTENT BY DEFAULT
 
   Examples: Remove tag but leave any content - these are just some examples, by default anything not specified separately will be treated like this
     | tagname   | html                                           |
@@ -31,7 +31,7 @@ Feature: Body processing Company Tags
   Examples:
      | before                                                         | after                                                         |
     # Text within the a tag is preserved:
-    | <p><company DICoName="Citigroup Inc" DICoFTMWTickercode="us:C" CompositeId="notconcorded">Not Concorded Comapny</company> more text here<company DICoName="Citigroup Inc" DICoFTMWTickercode="us:C" DICoTickerExchangeCode="" CompositeId="TnN0ZWluX09OX0ZvcnR1bmVDb21wYW55X0M=-T04=">Citigroup</company> has been picked to safeguard $230bn worth of securities.</p> |<p>Not Concorded Comapny more text here<ft-concept type="http://www.ft.com/ontology/company/PublicCompany" url="http://api.ft.com/organisations/704a3225-9b5c-3b4f-93c7-8e6a6993bfb0">Citigroup</ft-concept> has been picked to safeguard $230bn worth of securities.</p>               |
+    | <p><company DICoName="Citigroup Inc" DICoFTMWTickercode="us:C" CompositeId="notconcorded">Not Concorded Company</company> more text here<company DICoName="Citigroup Inc" DICoFTMWTickercode="us:C" DICoTickerExchangeCode="" CompositeId="TnN0ZWluX09OX0ZvcnR1bmVDb21wYW55X0M=-T04=">Citigroup</company> has been picked to safeguard $230bn worth of securities.</p> |<p>Not Concorded Company more text here<concept type="http://www.ft.com/ontology/company/PublicCompany" id="704a3225-9b5c-3b4f-93c7-8e6a6993bfb0">Citigroup</concept> has been picked to safeguard $230bn worth of securities.</p>               |
    
 
   Scenario Outline: Company tags are processed wherever they are in the story body xpath
@@ -41,7 +41,7 @@ Feature: Body processing Company Tags
   Examples:
     | before                                                         | after                                                         |
     # Text within the a tag is preserved:
-    | <b><company DICoName="Citigroup Inc" DICoFTMWTickercode="us:C"  DICoSEDOL="2297907"  DICoTickerSymbol="C" DICoTickerExchangeCode="" CompositeId="TnN0ZWluX09OX0ZvcnR1bmVDb21wYW55X0M=-T04=">Citigroup</company> has been picked to safeguard $230bn worth of securities.</b> | <strong><ft-concept type="http://www.ft.com/ontology/company/PublicCompany" url="http://api.ft.com/organisations/704a3225-9b5c-3b4f-93c7-8e6a6993bfb0">Citigroup</ft-concept> has been picked to safeguard $230bn worth of securities.</strong> |
-    | <company DICoName="Citigroup Inc" DICoFTMWTickercode="us:C"  DICoSEDOL="2297907"  DICoTickerSymbol="C" DICoTickerExchangeCode="" CompositeId="TnN0ZWluX09OX0ZvcnR1bmVDb21wYW55X0M=-T04=">Citigroup</company> has been picked to safeguard $230bn worth of securities.        | <ft-concept type="http://www.ft.com/ontology/company/PublicCompany" url="http://api.ft.com/organisations/704a3225-9b5c-3b4f-93c7-8e6a6993bfb0">Citigroup</ft-concept> has been picked to safeguard $230bn worth of securities.        |
+    | <b><company DICoName="Citigroup Inc" DICoFTMWTickercode="us:C"  DICoSEDOL="2297907"  DICoTickerSymbol="C" DICoTickerExchangeCode="" CompositeId="TnN0ZWluX09OX0ZvcnR1bmVDb21wYW55X0M=-T04=">Citigroup</company> has been picked to safeguard $230bn worth of securities.</b> | <strong><concept type="http://www.ft.com/ontology/company/PublicCompany" id="704a3225-9b5c-3b4f-93c7-8e6a6993bfb0">Citigroup</concept> has been picked to safeguard $230bn worth of securities.</strong> |
+    | <company DICoName="Citigroup Inc" DICoFTMWTickercode="us:C"  DICoSEDOL="2297907"  DICoTickerSymbol="C" DICoTickerExchangeCode="" CompositeId="TnN0ZWluX09OX0ZvcnR1bmVDb21wYW55X0M=-T04=">Citigroup</company> has been picked to safeguard $230bn worth of securities.        | <concept type="http://www.ft.com/ontology/company/PublicCompany" id="704a3225-9b5c-3b4f-93c7-8e6a6993bfb0">Citigroup</concept> has been picked to safeguard $230bn worth of securities.        |
 
  


### PR DESCRIPTION
- transform concorded companies to concept element with id and type,
extracting UUID from concordance apiUrl
- use XMLUnit, including in Cucumber tests, for comparing XML fragments
(attribute order is not significant)
- fix a few typos