### PR TITLE
Ignore Methode messages that are not FT source.

### DIFF
--- a/src/main/java/com/ft/methodearticlemapper/messaging/NativeCmsPublicationEventsListener.java
+++ b/src/main/java/com/ft/methodearticlemapper/messaging/NativeCmsPublicationEventsListener.java
@@ -1,5 +1,7 @@
 package com.ft.methodearticlemapper.messaging;
 
+import static com.ft.methodearticlemapper.model.EomFile.SOURCE_ATTR_XPATH;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ft.message.consumer.MessageListener;
 import com.ft.messaging.standards.message.v1.Message;
@@ -7,12 +9,24 @@ import com.ft.messaging.standards.message.v1.SystemId;
 import com.ft.methodearticlemapper.methode.EomFileType;
 import com.ft.methodearticlemapper.exception.MethodeArticleMapperException;
 import com.ft.methodearticlemapper.model.EomFile;
+import com.ft.methodearticlemapper.transformation.eligibility.PublishEligibilityChecker;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
 
 import java.io.IOException;
+import java.io.StringReader;
 import java.util.function.Predicate;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
 
 public class NativeCmsPublicationEventsListener implements MessageListener {
 
@@ -60,12 +74,34 @@ public class NativeCmsPublicationEventsListener implements MessageListener {
                 LOG.warn("Message filter failure", e);
                 return false;
             }
-            return isValidType(eomFile.getType());
+            return isValidType(eomFile.getType())
+                && isValidSource(eomFile.getAttributes());
         };
     }
 
     private boolean isValidType(String type) {
         return (EomFileType.EOMCompoundStory.getTypeName().equals(type)) ||
                 (EomFileType.EOMStory.getTypeName().equals((type)));
+    }
+    
+    private boolean isValidSource(String attributes) {
+      String sourceCode = null;
+      
+      try {
+        DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+        documentBuilderFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+        
+        DocumentBuilder db = documentBuilderFactory.newDocumentBuilder();
+        Document attributesDocument = db.parse(new InputSource(new StringReader(attributes)));
+        
+        XPath xpath = XPathFactory.newInstance().newXPath();
+        
+        sourceCode = xpath.evaluate(SOURCE_ATTR_XPATH, attributesDocument);
+      } catch (IOException | ParserConfigurationException | SAXException | XPathExpressionException e) {
+        LOG.warn("Unable to obtain EOMFile source", e);
+        // and fall through, to return false
+      }
+      
+      return PublishEligibilityChecker.isFTSource(sourceCode);
     }
 }

--- a/src/main/java/com/ft/methodearticlemapper/model/EomFile.java
+++ b/src/main/java/com/ft/methodearticlemapper/model/EomFile.java
@@ -13,6 +13,9 @@ public class EomFile {
     public static final String WEB_READY = "Stories/WebReady";
     public static final String WEB_CHANNEL = "FTcom";
 
+    public static final String SOURCE_ATTR_XPATH =
+        "/ObjectMetadata//EditorialNotes/Sources/Source/SourceCode";
+
     private final String uuid;
     private final String type;
 

--- a/src/main/java/com/ft/methodearticlemapper/transformation/eligibility/PublishEligibilityChecker.java
+++ b/src/main/java/com/ft/methodearticlemapper/transformation/eligibility/PublishEligibilityChecker.java
@@ -1,5 +1,7 @@
 package com.ft.methodearticlemapper.transformation.eligibility;
 
+import static com.ft.methodearticlemapper.model.EomFile.SOURCE_ATTR_XPATH;
+
 import com.google.common.base.Strings;
 
 import com.ft.methodearticlemapper.exception.EmbargoDateInTheFutureException;
@@ -44,12 +46,9 @@ import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 
 public abstract class PublishEligibilityChecker {
-
   protected static final String METHODE_XML_DATE_TIME_FORMAT = "yyyyMMddHHmmss";
   
   protected static final String CHANNEL_SYSTEM_ATTR_XPATH = "/props/productInfo/name";
-  protected static final String SOURCE_ATTR_XPATH =
-      "/ObjectMetadata//EditorialNotes/Sources/Source/SourceCode";
   
   private static final Logger LOG = LoggerFactory.getLogger(PublishEligibilityChecker.class);
   
@@ -240,7 +239,7 @@ public abstract class PublishEligibilityChecker {
     return EomFile.WEB_REVISE.equals(workflowStatus) || EomFile.WEB_READY.equals(workflowStatus);
   }
   
-  protected final boolean isFTSource(String source) {
+  public static boolean isFTSource(String source) {
     return "FT".equals(source);
   }
   


### PR DESCRIPTION
Rather than throw an exception, just log that we are ignoring these
messages. If such content is POSTed to the /content-transform endpoint,
it will still return a 4xx error response.