### PR TITLE
Map endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@
         <dependency>
             <groupId>com.github.Financial-Times</groupId>
             <artifactId>jax-rs-transaction-id-handling</artifactId>
-            <version>1.9.1</version>
+            <version>2.6.1</version>
         </dependency>
         <dependency>
             <groupId>com.github.Financial-Times</groupId>

--- a/src/main/java/com/ft/methodearticlemapper/MethodeArticleMapperApplication.java
+++ b/src/main/java/com/ft/methodearticlemapper/MethodeArticleMapperApplication.java
@@ -66,7 +66,7 @@ public class MethodeArticleMapperApplication extends Application<MethodeArticleM
             .info("JVM file.encoding = {}", System.getProperty("file.encoding"));
         
     	environment.servlets().addFilter("transactionIdFilter", new TransactionIdFilter())
-    		.addMappingForUrlPatterns(EnumSet.of(DispatcherType.REQUEST), true, "/content/*", "/content-transform/*");
+    		.addMappingForUrlPatterns(EnumSet.of(DispatcherType.REQUEST), true, "/content-transform/*", "/map");
 
     	BuildInfoResource buildInfoResource = new BuildInfoResource();
     	environment.jersey().register(buildInfoResource);

--- a/src/main/java/com/ft/methodearticlemapper/resources/PostContentToTransformResource.java
+++ b/src/main/java/com/ft/methodearticlemapper/resources/PostContentToTransformResource.java
@@ -26,7 +26,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 
-@Path("/content-transform")
+@Path("/")
 public class PostContentToTransformResource {
 
     private static final String CHARSET_UTF_8 = ";charset=utf-8";
@@ -40,15 +40,26 @@ public class PostContentToTransformResource {
 
 	@POST
 	@Timed
-	@Path("/{uuidString}")
+	@Path("/content-transform/{uuidString}")
 	@QueryParam("preview")
 	@Produces(MediaType.APPLICATION_JSON + CHARSET_UTF_8)
 	public final Content doTransform(@PathParam("uuidString") String uuid, @QueryParam("preview") boolean preview, EomFile eomFile, @Context HttpHeaders httpHeaders) {
-
-		String transactionId = TransactionIdUtils.getTransactionIdOrDie(httpHeaders, uuid, "Publish request");
+		String transactionId = TransactionIdUtils.getTransactionIdOrDie(httpHeaders);
 
 		validateUuid(uuid, eomFile);
 
+		return processRequest(uuid, preview, eomFile, transactionId);
+	}
+
+	@POST
+	@Timed
+	@Path("/map")
+	@Produces(MediaType.APPLICATION_JSON + CHARSET_UTF_8)
+	public final Content map(EomFile eomFile, @Context HttpHeaders httpHeaders) {
+        return doTransform(eomFile.getUuid(), false, eomFile, httpHeaders);
+	}
+
+	private Content processRequest(String uuid, boolean preview, EomFile eomFile, String transactionId) {
 		try {
 			if(preview) {
 				return eomFileProcessor.processPreview(eomFile, transactionId);
@@ -61,20 +72,20 @@ public class PostContentToTransformResource {
 					.reason(ErrorMessage.METHODE_FILE_NOT_FOUND)
 					.exception(e);
 		}catch(NotWebChannelException e){
-			throw ClientError.status(404)
+			throw ClientError.status(422)
 					.reason(ErrorMessage.NOT_WEB_CHANNEL)
 					.exception(e);
 		}catch(MethodeMissingFieldException e){
-			throw ClientError.status(404)
+			throw ClientError.status(422)
 					.error(String.format(ErrorMessage.METHODE_FIELD_MISSING.toString(), e.getFieldName()))
 					.exception(e);
 		}catch (MethodeMissingBodyException | UntransformableMethodeContentException e) {
-			throw ClientError.status(418)
+			throw ClientError.status(422)
 					.error(e.getMessage())
 					.exception(e);
 		}catch(MethodeContentNotEligibleForPublishException e){
-			throw ClientError.status(404)
-					.context(uuid.toString())
+			throw ClientError.status(422)
+					.context(uuid)
 					.error(e.getMessage())
 					.exception(e);
 		}
@@ -82,7 +93,7 @@ public class PostContentToTransformResource {
 
 	private void validateUuid(String uuid, EomFile eomFile) {
 		if (uuid == null) {
-			throw ClientError.status(400).context(uuid).reason(ErrorMessage.UUID_REQUIRED).exception();
+			throw ClientError.status(400).context(null).reason(ErrorMessage.UUID_REQUIRED).exception();
 		}
 		try {
 

--- a/src/main/java/com/ft/methodearticlemapper/resources/PostContentToTransformResource.java
+++ b/src/main/java/com/ft/methodearticlemapper/resources/PostContentToTransformResource.java
@@ -113,7 +113,7 @@ public class PostContentToTransformResource {
 	}
 
 	enum ErrorMessage {
-		METHODE_FILE_NOT_FOUND("Article cannot be found in Methode"),
+		METHODE_FILE_NOT_FOUND("Article marked as deleted"),
 		UUID_REQUIRED("No UUID was passed"),
 		INVALID_UUID("The UUID passed was invalid"),
 		METHODE_CONTENT_TYPE_NOT_SUPPORTED("Invalid request - resource not an article"),

--- a/src/test/java/com/ft/methodearticlemapper/resources/PostContentToTransformResourceForPreviewUnhappyPathsTest.java
+++ b/src/test/java/com/ft/methodearticlemapper/resources/PostContentToTransformResourceForPreviewUnhappyPathsTest.java
@@ -97,11 +97,11 @@ public class PostContentToTransformResourceForPreviewUnhappyPathsTest {
     }
 
     /**
-     * Tests that the response contains http code 404 and the correct message
+     * Tests that the response contains http code 422 and the correct message
      * when the type property in the json payload is not EOM::CompoundStory.
      */
     @Test
-    public void shouldThrow404ExceptionWhenPreviewNotEligibleForPublishing() {
+    public void shouldThrow422ExceptionWhenPreviewNotEligibleForPublishing() {
         UUID randomUuid = UUID.randomUUID();
         when(eomFile.getUuid()).thenReturn(randomUuid.toString());
         when(eomFileProcessor.processPreview(eomFile, TRANSACTION_ID)).
@@ -112,7 +112,7 @@ public class PostContentToTransformResourceForPreviewUnhappyPathsTest {
         } catch (WebApplicationClientException wace) {
             assertThat(((ErrorEntity)wace.getResponse().getEntity()).getMessage(),
                     equalTo(String.format("[%s] not an EOM::CompoundStory.", INVALID_TYPE)));
-            assertThat(wace.getResponse().getStatus(), equalTo(HttpStatus.SC_NOT_FOUND));
+            assertThat(wace.getResponse().getStatus(), equalTo(HttpStatus.SC_UNPROCESSABLE_ENTITY));
         }
     }
 }

--- a/src/test/java/com/ft/methodearticlemapper/resources/PostContentToTransformResourceForPublicationUnhappyPathsTest.java
+++ b/src/test/java/com/ft/methodearticlemapper/resources/PostContentToTransformResourceForPublicationUnhappyPathsTest.java
@@ -129,11 +129,11 @@ public class PostContentToTransformResourceForPublicationUnhappyPathsTest {
     }
 
     /**
-     * Tests that the response contains http code 404 and the correct message
+     * Tests that the response contains http code 422 and the correct message
      * when the type property in the json payload is not EOM::CompoundStory.
      */
     @Test
-    public void shouldThrow404ExceptionWhenPublicationNotEligibleForPublishing() {
+    public void shouldThrow422ExceptionWhenPublicationNotEligibleForPublishing() {
 
         when(eomFileProcessor.processPublication(eq(eomFile), eq(TRANSACTION_ID), any())).
                 thenThrow(new UnsupportedEomTypeException(uuid, "EOM::DistortedStory"));
@@ -143,16 +143,16 @@ public class PostContentToTransformResourceForPublicationUnhappyPathsTest {
         } catch (WebApplicationClientException wace) {
             assertThat(((ErrorEntity)wace.getResponse().getEntity()).getMessage(),
                     equalTo(String.format("[%s] not an EOM::CompoundStory.", INVALID_TYPE)));
-            assertThat(wace.getResponse().getStatus(), equalTo(HttpStatus.SC_NOT_FOUND));
+            assertThat(wace.getResponse().getStatus(), equalTo(HttpStatus.SC_UNPROCESSABLE_ENTITY));
         }
     }
 
     /**
-     * Tests that response contains 404 error code and the correct message
+     * Tests that response contains 422 error code and the correct message
      * when content that marked with an active publication embargo date is attempted to be published.
      */
     @Test
-    public void shouldThrow404ExceptionWhenEmbargoDateInTheFuture() {
+    public void shouldThrow422ExceptionWhenEmbargoDateInTheFuture() {
         Date embargoDate = new Date();
 
         when(eomFileProcessor.processPublication(eq(eomFile), eq(TRANSACTION_ID), any())).
@@ -163,16 +163,16 @@ public class PostContentToTransformResourceForPublicationUnhappyPathsTest {
         } catch (WebApplicationClientException wace) {
             assertThat(((ErrorEntity)wace.getResponse().getEntity()).getMessage(),
                     equalTo(String.format("Embargo date [%s] is in the future", embargoDate)));
-            assertThat(wace.getResponse().getStatus(), equalTo(HttpStatus.SC_NOT_FOUND));
+            assertThat(wace.getResponse().getStatus(), equalTo(HttpStatus.SC_UNPROCESSABLE_ENTITY));
         }
     }
 
     /**
-     * Tests that response contains 404 error code and the correct message
+     * Tests that response contains 422 error code and the correct message
      * when web channel element in eom file system attributes property indicates that the content is not eligible for publication.
      */
     @Test
-    public void shouldThrow404ExceptionWhenNotWebChannel() {
+    public void shouldThrow422ExceptionWhenNotWebChannel() {
 
         when(eomFileProcessor.processPublication(eq(eomFile), eq(TRANSACTION_ID), any())).
                 thenThrow(new NotWebChannelException(uuid));
@@ -182,16 +182,16 @@ public class PostContentToTransformResourceForPublicationUnhappyPathsTest {
         } catch (WebApplicationClientException wace) {
             assertThat(((ErrorEntity)wace.getResponse().getEntity()).getMessage(),
                     equalTo(PostContentToTransformResource.ErrorMessage.NOT_WEB_CHANNEL.toString()));
-            assertThat(wace.getResponse().getStatus(), equalTo(HttpStatus.SC_NOT_FOUND));
+            assertThat(wace.getResponse().getStatus(), equalTo(HttpStatus.SC_UNPROCESSABLE_ENTITY));
         }
     }
 
     /**
-     * Tests that response contains 404 error code and the correct message
+     * Tests that response contains 422 error code and the correct message
      * when web source element in eom file attributes property indicates that the content is not eligible for publication.
      */
     @Test
-    public void shouldThrow404ExceptionWhenSourceNotFt() {
+    public void shouldThrow422ExceptionWhenSourceNotFt() {
         final String sourceOtherThanFt = "Pepsi";
         when(eomFileProcessor.processPublication(eq(eomFile), eq(TRANSACTION_ID), any())).
                 thenThrow(new SourceNotEligibleForPublishException(uuid, sourceOtherThanFt));
@@ -201,16 +201,16 @@ public class PostContentToTransformResourceForPublicationUnhappyPathsTest {
         } catch (WebApplicationClientException wace) {
             assertThat(((ErrorEntity)wace.getResponse().getEntity()).getMessage(),
                     equalTo(String.format("Source [%s] not eligible for publishing", sourceOtherThanFt)));
-            assertThat(wace.getResponse().getStatus(), equalTo(HttpStatus.SC_NOT_FOUND));
+            assertThat(wace.getResponse().getStatus(), equalTo(HttpStatus.SC_UNPROCESSABLE_ENTITY));
         }
     }
 
     /**
-     * Tests that response contains 404 error code and the correct message
+     * Tests that response contains 422 error code and the correct message
      * when content with workFlow status ineligible for publication is attempted to be published.
      */
     @Test
-    public void shouldThrow404ExceptionWhenWorkflowStatusNotEligibleForPublishing() {
+    public void shouldThrow422ExceptionWhenWorkflowStatusNotEligibleForPublishing() {
 
         final String workflowStatusNotEligibleForPublishing = "Story/Edit";
         when(eomFileProcessor.processPublication(eq(eomFile), eq(TRANSACTION_ID), any())).
@@ -222,16 +222,16 @@ public class PostContentToTransformResourceForPublicationUnhappyPathsTest {
             assertThat(((ErrorEntity)wace.getResponse().getEntity()).getMessage(),
                     equalTo(String.format("Workflow status [%s] not eligible for publishing",
                             workflowStatusNotEligibleForPublishing)));
-            assertThat(wace.getResponse().getStatus(), equalTo(HttpStatus.SC_NOT_FOUND));
+            assertThat(wace.getResponse().getStatus(), equalTo(HttpStatus.SC_UNPROCESSABLE_ENTITY));
         }
     }
 
     /**
-     * Tests that response contains 404 error code and the correct message
+     * Tests that response contains 422 error code and the correct message
      * when content with missing publish date is attempted to be published.
      */
     @Test
-    public void shouldThrow404ExceptionWhenMethodeFieldMissing() {
+    public void shouldThrow422ExceptionWhenMethodeFieldMissing() {
         final String missingField = "publishedDate";
         when(eomFileProcessor.processPublication(eq(eomFile), eq(TRANSACTION_ID), any())).
                 thenThrow(new MethodeMissingFieldException(uuid, missingField));
@@ -242,17 +242,17 @@ public class PostContentToTransformResourceForPublicationUnhappyPathsTest {
             assertThat(((ErrorEntity)wace.getResponse().getEntity()).getMessage(),
                     equalTo(String.format(PostContentToTransformResource.ErrorMessage.METHODE_FIELD_MISSING.toString(),
                             missingField)));
-            assertThat(wace.getResponse().getStatus(), equalTo(HttpStatus.SC_NOT_FOUND));
+            assertThat(wace.getResponse().getStatus(), equalTo(HttpStatus.SC_UNPROCESSABLE_ENTITY));
         }
     }
 
     /**
-     * Tests that response contains 418 error code and the correct message
+     * Tests that response contains 422 error code and the correct message
      * when eom-file with missing or empty value property or its value property translates into
      * an empty content body is attempted to be published.
      */
     @Test
-    public void shouldThrow418ExceptionWhenMethodeBodyMissing() {
+    public void shouldThrow422ExceptionWhenMethodeBodyMissing() {
         when(eomFileProcessor.processPublication(eq(eomFile), eq(TRANSACTION_ID), any())).
                 thenThrow(new MethodeMissingBodyException(uuid));
         try {
@@ -261,17 +261,17 @@ public class PostContentToTransformResourceForPublicationUnhappyPathsTest {
         } catch (WebApplicationClientException e) {
             assertThat(((ErrorEntity)e.getResponse().getEntity()).getMessage(),
                     containsString(uuid.toString()));
-            assertThat(e.getResponse().getStatus(), equalTo(418));
+            assertThat(e.getResponse().getStatus(), equalTo(HttpStatus.SC_UNPROCESSABLE_ENTITY));
         }
     }
     
     
-   /* Tests that response contains 418 error code and the correct message
+   /* Tests that response contains 422 error code and the correct message
     * when eom-file with missing or empty value property or its value property translates into
     * an blank content body post transformation is attempted to be published.
     */
    @Test
-   public void shouldThrow418ExceptionWhenMethodeBodyBlankAfterTransformation() {
+   public void shouldThrow422ExceptionWhenMethodeBodyBlankAfterTransformation() {
        when(eomFileProcessor.processPublication(eq(eomFile), eq(TRANSACTION_ID), any())).
                thenThrow(new UntransformableMethodeContentException(uuid.toString(), "it's blank"));
        try {
@@ -280,7 +280,7 @@ public class PostContentToTransformResourceForPublicationUnhappyPathsTest {
        } catch (WebApplicationClientException e) {
            assertThat(((ErrorEntity)e.getResponse().getEntity()).getMessage(),
                    containsString("it's blank"));
-           assertThat(e.getResponse().getStatus(), equalTo(418));
+           assertThat(e.getResponse().getStatus(), equalTo(HttpStatus.SC_UNPROCESSABLE_ENTITY));
        }
    }
 }


### PR DESCRIPTION
1. Added /map endpoint, alternative to /content-transform/{uuid}. Reason is consistency across the mappers & simplified URLs. Next step will be to remove the /content-transform/{uuid} altogether.
2. Reviewed status codes
3. Incremented transaction utils dependency.