### PR TITLE
Bugfix/build info version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 FROM coco/dropwizardbase:0.7.x-mvn333
 
-COPY . /
+COPY . /methode-article-mapper
 
 RUN apk --update add git \
+ && cd methode-article-mapper \
  && HASH=$(git log -1 --pretty=format:%H) \
- && VERSION=$(git tag -l --contains $HASH) \
+ && TAG=$(git tag -l --contains $HASH) \
+ && VERSION=${TAG:-untagged} \
  && mvn versions:set -DnewVersion=$VERSION \
  && mvn install -Dbuild.git.revision=$HASH -Djava.net.preferIPv4Stack=true \
  && rm -f target/methode-article-mapper-*sources.jar \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ COPY . /
 
 RUN apk --update add git \
  && HASH=$(git log -1 --pretty=format:%H) \
+ && VERSION=$(git tag -l --contains $HASH) \
+ && mvn versions:set -DnewVersion=$VERSION \
  && mvn install -Dbuild.git.revision=$HASH -Djava.net.preferIPv4Stack=true \
  && rm -f target/methode-article-mapper-*sources.jar \
  && mv target/methode-article-mapper-*.jar /methode-article-mapper.jar \


### PR DESCRIPTION
This follows the approach we previously took with Jenkins builds, of setting the version in the POM file so that the build-info plugin will do its work. There were a couple of quirks - I've made it use the string "untagged" if the Git commit it's building from is not tagged, and I found that the Maven version plugin wouldn't run successfully from the root directory (of the container).