### PR TITLE
UPP-903: Add accessLevel field to content

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -71,7 +71,8 @@ You can find an example of a transformed article below.
   "webUrl": null,
   "publishReference": "tid_dn4kzqpoxf",
   "lastModified": "2016-08-25T06:06:23.532Z",
-  "canBeSyndicated": "yes"
-  "firstPublishedDate": "2016-08-15T10:31:22.000Z"
+  "canBeSyndicated": "yes",
+  "firstPublishedDate": "2016-08-15T10:31:22.000Z",
+  "accessLevel": "subscribed"
 }
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
         <dependency>
             <groupId>com.github.Financial-Times</groupId>
             <artifactId>content-model</artifactId>
-            <version>0.1.42</version>
+            <version>0.1.43</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.hibernate</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
         <dependency>
             <groupId>com.github.Financial-Times</groupId>
             <artifactId>content-model</artifactId>
-            <version>0.1.41</version>
+            <version>0.1.42</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.hibernate</groupId>

--- a/src/main/java/com/ft/methodearticlemapper/exception/InvalidSubscriptionLevelException.java
+++ b/src/main/java/com/ft/methodearticlemapper/exception/InvalidSubscriptionLevelException.java
@@ -1,0 +1,9 @@
+package com.ft.methodearticlemapper.exception;
+
+
+public class InvalidSubscriptionLevelException extends RuntimeException {
+
+    public InvalidSubscriptionLevelException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/ft/methodearticlemapper/transformation/EomFileProcessor.java
+++ b/src/main/java/com/ft/methodearticlemapper/transformation/EomFileProcessor.java
@@ -225,10 +225,15 @@ public class EomFileProcessor {
 
     private AccessLevel getAccessLevel(final XPath xpath, Document attributes, UUID uuid) throws XPathExpressionException {
         SubscriptionLevel subscriptionLevel;
+        String value = null;
         try {
-            subscriptionLevel = SubscriptionLevel.fromInt(Integer.parseInt(xpath.evaluate(SUBSCRIPTION_LEVEL_XPATH, attributes)));
-        } catch (InvalidSubscriptionLevelException | NumberFormatException e) {
+            value = xpath.evaluate(SUBSCRIPTION_LEVEL_XPATH, attributes);
+            subscriptionLevel = SubscriptionLevel.fromInt(Integer.parseInt(value));
+        } catch (InvalidSubscriptionLevelException e) {
             throw new UntransformableMethodeContentException(uuid.toString(), e.getMessage());
+        } catch (NumberFormatException e) {
+            throw new UntransformableMethodeContentException(uuid.toString(),
+                    String.format("Cannot return subscription level for value: %s", value));
         }
 
         switch (subscriptionLevel) {

--- a/src/main/java/com/ft/methodearticlemapper/transformation/SubscriptionLevel.java
+++ b/src/main/java/com/ft/methodearticlemapper/transformation/SubscriptionLevel.java
@@ -1,0 +1,34 @@
+package com.ft.methodearticlemapper.transformation;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.ft.methodearticlemapper.exception.InvalidSubscriptionLevelException;
+
+public enum SubscriptionLevel {
+
+    FOLLOW_USUAL_RULES(0),
+    SHOWCASE(2),
+    PREMIUM(3);
+
+    private int subscriptionLevel;
+
+    SubscriptionLevel(int subscriptionLevel) {
+        this.subscriptionLevel = subscriptionLevel;
+    }
+
+    public static SubscriptionLevel fromInt(int subscriptionLevel) {
+        for (SubscriptionLevel level : SubscriptionLevel.values()) {
+            if (subscriptionLevel == level.getSubscriptionLevel()) {
+                return level;
+            }
+        }
+
+        throw new InvalidSubscriptionLevelException(
+                String.format("Cannot return subscription level for value %d", subscriptionLevel)
+        );
+    }
+
+    @JsonValue
+    public int getSubscriptionLevel() {
+        return subscriptionLevel;
+    }
+}

--- a/src/test/java/com/ft/methodearticlemapper/transformation/EomFileAttributesBuilder.java
+++ b/src/test/java/com/ft/methodearticlemapper/transformation/EomFileAttributesBuilder.java
@@ -75,6 +75,11 @@ class EomFileAttributesBuilder {
         return this;
     }
 
+    EomFileAttributesBuilder withSubscriptionLevel(String subscriptionLevel) {
+        this.attributes.put("subscriptionLevel", subscriptionLevel);
+        return this;
+    }
+
     String build() {
         Template mustache = Mustache.compiler().compile(attributesTemplate);
         return mustache.execute(attributes);

--- a/src/test/resources/article/article_attributes.xml.mustache
+++ b/src/test/resources/article/article_attributes.xml.mustache
@@ -8,6 +8,7 @@
             <DIFTcomMarkDeleted>{{deleted}}</DIFTcomMarkDeleted>
             <DIFTcomArticleImage>{{articleImage}}</DIFTcomArticleImage>
             <DIFTcomDiscussion>{{comments}}</DIFTcomDiscussion>
+            <DIFTcomSubscriptionLevel>{{subscriptionLevel}}</DIFTcomSubscriptionLevel>
             <editorsPick>{{editorsPick}}</editorsPick>
             <exclusive>{{exclusive}}</exclusive>
             <scoop>{{scoop}}</scoop>

--- a/src/test/resources/article/article_attributes_no_contributor_rights.xml.mustache
+++ b/src/test/resources/article/article_attributes_no_contributor_rights.xml.mustache
@@ -8,6 +8,7 @@
             <DIFTcomMarkDeleted>{{deleted}}</DIFTcomMarkDeleted>
             <DIFTcomArticleImage>{{articleImage}}</DIFTcomArticleImage>
             <DIFTcomDiscussion>{{comments}}</DIFTcomDiscussion>
+            <DIFTcomSubscriptionLevel>{{subscriptionLevel}}</DIFTcomSubscriptionLevel>
             <editorsPick>{{editorsPick}}</editorsPick>
             <exclusive>{{exclusive}}</exclusive>
             <scoop>{{scoop}}</scoop>

--- a/src/test/resources/preview/article_preview_attributes.xml
+++ b/src/test/resources/preview/article_preview_attributes.xml
@@ -1,3 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE ObjectMetadata SYSTEM "/SysConfig/Classify/FTStories/classify.dtd">
-<ObjectMetadata>\n</ObjectMetadata>
+<ObjectMetadata>
+    <OutputChannels>
+        <DIFTcom>
+            <DIFTcomSubscriptionLevel>0</DIFTcomSubscriptionLevel>
+        </DIFTcom>
+    </OutputChannels>
+</ObjectMetadata>


### PR DESCRIPTION
accessLevel is a new field for content which gets it's value from DIFTcomSubscriptionLevel methode attribute. 

The mapping is:
0 (FOLLOW_USUAL_RULES) -> "subscribed"
2 (SHOWCASE) -> "free"
3 (PREMIUM) -> "premium"
