### PR TITLE
Rework links processing

### DIFF
--- a/methode-article-mapper.yaml
+++ b/methode-article-mapper.yaml
@@ -78,7 +78,7 @@ logging:
 documentStoreApi:
     endpointConfiguration:
         shortName: "documentStoreApi"
-        path: content/
+        path: "/content/getMultiple"
         jerseyClient:
             timeout: 2000ms    
         primaryNodes: ["localhost:8080:8080", "localhost:8080:8080"]

--- a/methode-article-mapper.yaml
+++ b/methode-article-mapper.yaml
@@ -78,7 +78,7 @@ logging:
 documentStoreApi:
     endpointConfiguration:
         shortName: "documentStoreApi"
-        path: "/content/getMultiple"
+        path: "/content"
         jerseyClient:
             timeout: 2000ms    
         primaryNodes: ["localhost:8080:8080", "localhost:8080:8080"]

--- a/src/main/java/com/ft/methodearticlemapper/exception/DocumentStoreApiInvalidRequestException.java
+++ b/src/main/java/com/ft/methodearticlemapper/exception/DocumentStoreApiInvalidRequestException.java
@@ -1,0 +1,8 @@
+package com.ft.methodearticlemapper.exception;
+
+public class DocumentStoreApiInvalidRequestException extends RuntimeException {
+
+    public DocumentStoreApiInvalidRequestException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/ft/methodearticlemapper/exception/DocumentStoreApiUnmarshallingException.java
+++ b/src/main/java/com/ft/methodearticlemapper/exception/DocumentStoreApiUnmarshallingException.java
@@ -1,0 +1,8 @@
+package com.ft.methodearticlemapper.exception;
+
+public class DocumentStoreApiUnmarshallingException extends RuntimeException {
+
+    public DocumentStoreApiUnmarshallingException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/ft/methodearticlemapper/model/Content.java
+++ b/src/main/java/com/ft/methodearticlemapper/model/Content.java
@@ -1,0 +1,23 @@
+package com.ft.methodearticlemapper.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Content {
+    private String uuid;
+    private String type;
+
+    public Content(@JsonProperty("uuid") String uuid,
+                   @JsonProperty("type") String type) {
+        this.uuid = uuid;
+        this.type = type;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+
+    public String getUuid() {
+        return uuid;
+    }
+}

--- a/src/main/java/com/ft/methodearticlemapper/transformation/MethodeLinksBodyProcessor.java
+++ b/src/main/java/com/ft/methodearticlemapper/transformation/MethodeLinksBodyProcessor.java
@@ -24,6 +24,7 @@ import org.xml.sax.InputSource;
 
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response.Status.Family;
+import javax.ws.rs.core.UriBuilder;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -40,6 +41,7 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.net.URI;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -92,7 +94,7 @@ public class MethodeLinksBodyProcessor implements BodyProcessor {
                     removeATag(aTag);
                 } else {
                     Optional<String> optionalUuid = extractUuid(aTag);
-                    optionalUuid.ifPresent(s -> aTagsToCheck.put(aTag, s));
+                    optionalUuid.ifPresent(uuid -> aTagsToCheck.put(aTag, uuid));
                 }
             }
 
@@ -173,14 +175,16 @@ public class MethodeLinksBodyProcessor implements BodyProcessor {
             return Collections.emptyList();
         }
 
+        Collection<String> uuids = tags.values();
+        URI documentsUri = UriBuilder.fromUri(uri).queryParam("mget", true).build();
         ClientResponse clientResponse = null;
         try {
-            clientResponse = documentStoreApiClient.resource(uri)
+            clientResponse = documentStoreApiClient.resource(documentsUri)
                     .accept(MediaType.APPLICATION_JSON_TYPE)
                     .type(MediaType.APPLICATION_JSON_TYPE)
                     .header(TransactionIdUtils.TRANSACTION_ID_HEADER, transactionId)
                     .header("Host", "document-store-api")
-                    .post(ClientResponse.class, tags.values().stream().distinct().toArray());
+                    .post(ClientResponse.class, uuids);
 
             int responseStatusCode = clientResponse.getStatus();
             Family statusFamily = getFamilyByStatusCode(responseStatusCode);

--- a/src/main/java/com/ft/methodearticlemapper/transformation/MethodeLinksBodyProcessor.java
+++ b/src/main/java/com/ft/methodearticlemapper/transformation/MethodeLinksBodyProcessor.java
@@ -24,7 +24,6 @@ import org.xml.sax.InputSource;
 
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response.Status.Family;
-import javax.ws.rs.core.UriBuilder;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -174,14 +173,14 @@ public class MethodeLinksBodyProcessor implements BodyProcessor {
             return Collections.emptyList();
         }
 
-        URI documentsUri = UriBuilder.fromUri(uri).queryParam("uuid", tags.values().stream().distinct().toArray()).build();
         ClientResponse clientResponse = null;
         try {
-            clientResponse = documentStoreApiClient.resource(documentsUri)
+            clientResponse = documentStoreApiClient.resource(uri)
                     .accept(MediaType.APPLICATION_JSON_TYPE)
+                    .type(MediaType.APPLICATION_JSON_TYPE)
                     .header(TransactionIdUtils.TRANSACTION_ID_HEADER, transactionId)
                     .header("Host", "document-store-api")
-                    .get(ClientResponse.class);
+                    .post(ClientResponse.class, tags.values().stream().distinct().toArray());
 
             int responseStatusCode = clientResponse.getStatus();
             Family statusFamily = getFamilyByStatusCode(responseStatusCode);

--- a/src/main/java/com/ft/methodearticlemapper/transformation/MethodeLinksBodyProcessor.java
+++ b/src/main/java/com/ft/methodearticlemapper/transformation/MethodeLinksBodyProcessor.java
@@ -1,24 +1,29 @@
 package com.ft.methodearticlemapper.transformation;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ft.api.util.transactionid.TransactionIdUtils;
 import com.ft.bodyprocessing.BodyProcessingContext;
 import com.ft.bodyprocessing.BodyProcessingException;
 import com.ft.bodyprocessing.BodyProcessor;
 import com.ft.bodyprocessing.TransactionIdBodyProcessingContext;
 import com.ft.jerseyhttpwrapper.ResilientClient;
+import com.ft.methodearticlemapper.exception.DocumentStoreApiUnmarshallingException;
+import com.ft.methodearticlemapper.exception.DocumentStoreApiInvalidRequestException;
 import com.ft.methodearticlemapper.exception.DocumentStoreApiUnavailableException;
-import com.google.common.base.Optional;
+import com.ft.methodearticlemapper.model.Content;
 import com.sun.jersey.api.client.ClientHandlerException;
 import com.sun.jersey.api.client.ClientResponse;
+import org.apache.commons.lang.StringUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
-import org.xml.sax.SAXException;
 
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response.Status.Family;
 import javax.ws.rs.core.UriBuilder;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -30,35 +35,38 @@ import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
-import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.net.URI;
-
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.HashMap;
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static com.sun.jersey.api.client.ClientResponse.Status.getFamilyByStatusCode;
 
 public class MethodeLinksBodyProcessor implements BodyProcessor {
 
-	private static final String CONTENT_TAG = "content";
-	public static final String ARTICLE_TYPE = "http://www.ft.com/ontology/content/Article";
+    static final String BASE_CONTENT_TYPE = "http://www.ft.com/ontology/content/";
+    static final String DEFAULT_CONTENT_TYPE = "http://www.ft.com/ontology/content/Content";
+
+    private static final String CONTENT_TAG = "content";
+    private static final String ANCHOR_PREFIX = "#";
+    private static final String TYPE = "type";
     private static final String UUID_REGEX = ".*([0-9a-f]{8}\\-[0-9a-f]{4}\\-[0-9a-f]{4}\\-[0-9a-f]{4}\\-[0-9a-f]{12}).*";
     private static final Pattern UUID_REGEX_PATTERN = Pattern.compile(UUID_REGEX);
     private static final String UUID_PARAM_REGEX = ".*uuid=" + UUID_REGEX;
     private static final Pattern UUID_PARAM_REGEX_PATTERN = Pattern.compile(UUID_PARAM_REGEX);
+    private static final String FT_COM_URL_REGEX = "^https*:\\/\\/www.ft.com\\/.*";
+    private static final Pattern FT_COM_URL_REGEX_PATTERN = Pattern.compile(FT_COM_URL_REGEX);
 
-	private static final String ANCHOR_PREFIX = "#";
-    public static final String FT_COM_WWW_URL = "http://www.ft.com/";
-	public static final String TYPE = "type";
-	private ResilientClient documentStoreApiClient;
+    private ResilientClient documentStoreApiClient;
     private URI uri;
 
 	public MethodeLinksBodyProcessor(ResilientClient documentStoreApiClient, URI uri) {
@@ -68,52 +76,42 @@ public class MethodeLinksBodyProcessor implements BodyProcessor {
 
     @Override
     public String process(String body, BodyProcessingContext bodyProcessingContext) throws BodyProcessingException {
-        if (body != null && !body.trim().isEmpty()) {
-
-            final Document document;
-            try {
-                final DocumentBuilder documentBuilder = getDocumentBuilder();
-                document = documentBuilder.parse(new InputSource(new StringReader(body)));
-            } catch (ParserConfigurationException | SAXException | IOException e) {
-                throw new BodyProcessingException(e);
-            }
-
-            final List<Node> aTagsToCheck = new ArrayList<>();
-            final XPath xpath = XPathFactory.newInstance().newXPath();
-            try {
-                final NodeList aTags = (NodeList) xpath.evaluate("//a[count(ancestor::promo-link)=0]", document, XPathConstants.NODESET);
-                for (int i = 0; i < aTags.getLength(); i++) {
-                    final Element aTag = (Element)aTags.item(i);
-                    
-                    if (isRemovable(aTag)) {
-                    	removeATag(aTag);
-                    }
-                    else if (containsUuid(getHref(aTag))) {
-                        aTagsToCheck.add(aTag);
-                    }
-                }
-            } catch (XPathExpressionException e) {
-                throw new BodyProcessingException(e);
-            }
-
-            final Set<String> uuidsToCheck = extractUuids(aTagsToCheck);
-
-			if (bodyProcessingContext instanceof TransactionIdBodyProcessingContext) {
-				TransactionIdBodyProcessingContext transactionIdBodyProcessingContext =
-						(TransactionIdBodyProcessingContext) bodyProcessingContext;
-				
-				final List<String> uuidsPresentInContentStore = getUuidsPresentInContentStore(uuidsToCheck, transactionIdBodyProcessingContext.getTransactionId());
-
-				processATags(aTagsToCheck, uuidsPresentInContentStore);
-
-				final String modifiedBody = serializeBody(document);
-				return modifiedBody;
-			} else {
-				IllegalStateException up = new IllegalStateException("bodyProcessingContext should provide transaction id.");
-				throw up;
-			}
+        if (StringUtils.isBlank(body)) {
+            return body;
         }
-        return body;
+        try {
+            final DocumentBuilder documentBuilder = getDocumentBuilder();
+            final Document document = documentBuilder.parse(new InputSource(new StringReader(body)));
+
+            final Map<Node, String> aTagsToCheck = new HashMap<>();
+            final XPath xpath = XPathFactory.newInstance().newXPath();
+            final NodeList aTags = (NodeList) xpath.evaluate("//a[count(ancestor::promo-link)=0]", document, XPathConstants.NODESET);
+            for (int i = 0; i < aTags.getLength(); i++) {
+                final Element aTag = (Element) aTags.item(i);
+
+                if (isRemovable(aTag)) {
+                    removeATag(aTag);
+                } else {
+                    Optional<String> optionalUuid = extractUuid(aTag);
+                    optionalUuid.ifPresent(s -> aTagsToCheck.put(aTag, s));
+                }
+            }
+
+            if (!(bodyProcessingContext instanceof TransactionIdBodyProcessingContext)) {
+                throw new IllegalStateException("bodyProcessingContext should provide transaction id.");
+            }
+
+            TransactionIdBodyProcessingContext transactionIdBodyProcessingContext = (TransactionIdBodyProcessingContext) bodyProcessingContext;
+            String transactionId = transactionIdBodyProcessingContext.getTransactionId();
+            if (StringUtils.isBlank(transactionId)) {
+                throw new IllegalStateException("bodyProcessingContext should provide transaction id.");
+            }
+            final List<Content> content = getContentFromDocumentStore(aTagsToCheck, transactionId);
+            processATags(aTagsToCheck, content);
+            return serializeBody(document);
+        } catch (Exception e) {
+            throw new BodyProcessingException(e);
+        }
     }
 
     /**
@@ -123,6 +121,7 @@ public class MethodeLinksBodyProcessor implements BodyProcessor {
      * <li>with hrefs that contain only a fragment identifier (a part of the current document);</li>
      * <li>with no non-whitespace content <i>and</i> no <code>data-*</code> attributes.</li>
      * </ul>
+     *
      * @param aTag the tag
      * @return true if removable, otherwise false.
      */
@@ -151,7 +150,6 @@ public class MethodeLinksBodyProcessor implements BodyProcessor {
                     
                 default: // any other node type
                     return false;
-                
             }
         }
         
@@ -169,70 +167,54 @@ public class MethodeLinksBodyProcessor implements BodyProcessor {
         }
         
         return true;
-	}
-	
-    private List<String> getUuidsPresentInContentStore(Set<String> uuidsToCheck, String transactionId) {
-        if(uuidsToCheck.isEmpty()) {
-            return Collections.emptyList();
-        }
-        
-        List<String> uuidsPresentInContentStore = new ArrayList<>();
-        
-        for (String uuidToCheck: uuidsToCheck) {
-            if (existsInDocumentStore(uuidToCheck, transactionId)) {
-                uuidsPresentInContentStore.add(uuidToCheck);
-            }
-        }
-        return uuidsPresentInContentStore;
     }
 
-	private boolean existsInDocumentStore(String idToCheck, String transactionId) {
-        int responseStatusCode;
-        ClientResponse clientResponse = null;
-		URI contentUrl = contentUrlBuilder().build(idToCheck);
-		try {
-			clientResponse = documentStoreApiClient.resource(contentUrl)
-					.accept(MediaType.APPLICATION_JSON_TYPE)
-					.header(TransactionIdUtils.TRANSACTION_ID_HEADER, transactionId)
-                    .header("Host", "document-store-api")
-					.get(ClientResponse.class);
-            
-            responseStatusCode = clientResponse.getStatus();
+    private List<Content> getContentFromDocumentStore(Map<Node, String> tags, String transactionId) {
+        if (tags.isEmpty()) {
+            return Collections.emptyList();
         }
-        catch (ClientHandlerException che) {
-			Throwable cause = che.getCause();
-			if(cause instanceof IOException) {
-				throw new DocumentStoreApiUnavailableException(che);
-			}
-			throw che;
-		}
-        finally {
+
+        URI documentsUri = UriBuilder.fromUri(uri).queryParam("uuid", tags.values().stream().distinct().toArray()).build();
+        ClientResponse clientResponse = null;
+        try {
+            clientResponse = documentStoreApiClient.resource(documentsUri)
+                    .accept(MediaType.APPLICATION_JSON_TYPE)
+                    .header(TransactionIdUtils.TRANSACTION_ID_HEADER, transactionId)
+                    .header("Host", "document-store-api")
+                    .get(ClientResponse.class);
+
+            int responseStatusCode = clientResponse.getStatus();
+            Family statusFamily = getFamilyByStatusCode(responseStatusCode);
+
+            if (statusFamily == Family.SERVER_ERROR) {
+                String msg = String.format("Document Store API returned %s", responseStatusCode);
+                throw new DocumentStoreApiUnavailableException(msg);
+            } else if (statusFamily == Family.CLIENT_ERROR) {
+                String msg = String.format("Document Store API returned %s", responseStatusCode);
+                throw new DocumentStoreApiInvalidRequestException(msg);
+            }
+
+            ObjectMapper mapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+            String jsonAsString = clientResponse.getEntity(String.class);
+            Content[] returnedContent = mapper.readValue(jsonAsString, Content[].class);
+
+            return Arrays.asList(returnedContent);
+        } catch (ClientHandlerException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof IOException) {
+                throw new DocumentStoreApiUnavailableException(e);
+            }
+            throw e;
+        } catch (IOException e) {
+            throw new DocumentStoreApiUnmarshallingException("Failed to parse content received from Document Store API", e);
+        } finally {
             if (clientResponse != null) {
                 clientResponse.close();
             }
         }
+    }
 
-		int responseStatusFamily = responseStatusCode / 100;
-        
-        if (responseStatusFamily == 5) {
-            // can't tell whether it exists
-            String msg = String.format("Document store API returned %s", responseStatusCode);
-            throw new DocumentStoreApiUnavailableException(msg);
-        }
-
-		return responseStatusFamily == 2;
-	}
-
-	private UriBuilder contentUrlBuilder() {
-		return UriBuilder.fromUri(uri).path("{uuid}");
-
-	}
-
-	private String serializeBody(Document document) {
-//        final DOMImplementationLS implementation = (DOMImplementationLS) document.getImplementation();
-//        final LSSerializer serializer = implementation.createLSSerializer();
-//        final String result = serializer.writeToString(document);
-//        return result;
+    private String serializeBody(Document document) {
         final DOMSource domSource = new DOMSource(document);
         final StringWriter writer = new StringWriter();
         final StreamResult result = new StreamResult(writer);
@@ -243,89 +225,86 @@ public class MethodeLinksBodyProcessor implements BodyProcessor {
             transformer.setOutputProperty("standalone", "yes");
             transformer.transform(domSource, result);
             writer.flush();
-            final String body = writer.toString();
-            return body;
+            return writer.toString();
         } catch (TransformationException | TransformerException e) {
             throw new BodyProcessingException(e);
         }
     }
-	
 
-
-    private void processATags(List<Node> aTagsToCheck, List<String> uuidsPresentInContentStore) {
-        for(Node node : aTagsToCheck){
-            Optional<String> assetUuid = extractUuid(node);
-            if(assetUuid.isPresent()){
-                String uuid = assetUuid.get();
-                if (uuidsPresentInContentStore.contains(uuid)) {
-                    replaceLinkToContentPresentInDocumentStore(node, uuid);
-                } else if (isConvertableToAssetOnFtCom(node)){
-                    transformLinkToAssetOnFtCom(node, uuid); // e.g slideshow galleries
-                } else {
-                    // leave it alone, we don't know what to do with it
-                }
+    private void processATags(Map<Node, String> aTags, List<Content> content) {
+        for (Node aTag : aTags.keySet()) {
+            Optional<Content> matchingContent = getMatchingContent(content, aTags.get(aTag));
+            if (matchingContent.isPresent()) {
+                replaceLinkToContentPresentInDocumentStore(aTag, matchingContent.get());
+            } else if (isConvertibleToAssetOnFtCom(aTag)) {
+                transformLinkToAssetOnFtCom(aTag, aTags.get(aTag));
             }
         }
     }
-	
-	private boolean isConvertableToAssetOnFtCom(Node node) {
-		String href = getHref(node);
-		if (href.startsWith(FT_COM_WWW_URL)) {
-			return true;
-		} else if (href.startsWith("/")) { // i.e. it's a relative path in Methode with a UUID param		
-			Matcher matcher = UUID_PARAM_REGEX_PATTERN.matcher(href);
-			if(matcher.matches()){
-				return true;
-			}
-		}
+
+    private Optional<Content> getMatchingContent(List<Content> content, String uuid) {
+        return content.stream().filter(c -> c.getUuid().equals(uuid)).findFirst();
+    }
+
+    private void replaceLinkToContentPresentInDocumentStore(Node node, Content content) {
+        Element newElement = node.getOwnerDocument().createElement(CONTENT_TAG);
+        newElement.setAttribute("id", content.getUuid());
+
+        if (!StringUtils.isBlank(content.getType())) {
+            newElement.setAttribute("type", BASE_CONTENT_TYPE + content.getType());
+        } else {
+            newElement.setAttribute("type", DEFAULT_CONTENT_TYPE);
+        }
+
+        Optional<String> nodeValue = getTitleAttributeIfExists(node);
+        nodeValue.ifPresent(s -> newElement.setAttribute("title", s));
+        newElement.setTextContent(node.getTextContent());
+        node.getParentNode().replaceChild(newElement, node);
+    }
+
+    private Optional<String> getTitleAttributeIfExists(Node node) {
+        if (getAttribute(node, "title") != null) {
+            String nodeValue = getAttribute(node, "title").getNodeValue();
+            return Optional.ofNullable(nodeValue);
+        }
+        return Optional.empty();
+    }
+
+    private boolean isConvertibleToAssetOnFtCom(Node node) {
+        String href = getHref(node);
+        Matcher matcher = FT_COM_URL_REGEX_PATTERN.matcher(href);
+        if (matcher.matches()) {
+            return true;
+        } else if (href.startsWith("/")) { // i.e. it's a relative path in Methode with a UUID param
+            matcher = UUID_PARAM_REGEX_PATTERN.matcher(href);
+            if (matcher.matches()) {
+                return true;
+            }
+        }
         return false;
-		
-	}
+    }
 
-	private void replaceLinkToContentPresentInDocumentStore(Node node, String uuid) {
-		Element newElement = node.getOwnerDocument().createElement(CONTENT_TAG);
-		newElement.setAttribute("id", uuid);
-		newElement.setAttribute("type", ARTICLE_TYPE);
-		Optional<String> nodeValue = getTitleAttributeIfExists(node);
-		if(nodeValue.isPresent()){
-			newElement.setAttribute("title", nodeValue.get());
-		}
-		newElement.setTextContent(node.getTextContent());
-		node.getParentNode().replaceChild(newElement, node);
-	}
-
-	private Optional<String> getTitleAttributeIfExists(Node node) {
-		if(getAttribute(node, "title") != null){
-			String nodeValue = getAttribute(node, "title").getNodeValue();
-			return Optional.fromNullable(nodeValue);
-		}
-		return Optional.absent();
-	}
-
-	private void transformLinkToAssetOnFtCom(Node aTag, String uuid) {
-
+    private void transformLinkToAssetOnFtCom(Node aTag, String uuid) {
         String oldHref = getHref(aTag);
         String newHref;
 
-        if(oldHref.startsWith(FT_COM_WWW_URL)) {
-
+        Matcher matcher = FT_COM_URL_REGEX_PATTERN.matcher(oldHref);
+        if (matcher.matches()) {
             URI ftAssetUri = URI.create(oldHref);
-
             String path = ftAssetUri.getPath();
 
-            if(path.startsWith("/intl")) {
-                newHref =  ftAssetUri.resolve(path.substring(5)).toString();
+            if (path.startsWith("/intl")) {
+                newHref = ftAssetUri.resolve(path.substring(5)).toString();
             } else {
                 if (isSlideshowUrl(aTag)) {
                     newHref = oldHref;
                 } else {
                     // do this to get rid of query params and fragment identifiers from the url
-                    newHref =  ftAssetUri.resolve(path).toString();                    
+                    newHref = ftAssetUri.resolve(path).toString();
                 }
             }
-
         } else {
-            newHref = "http://www.ft.com/cms/s/"+ uuid + ".html";
+            newHref = "http://www.ft.com/cms/s/" + uuid + ".html";
         }
 
         getAttribute(aTag, "href").setNodeValue(newHref);
@@ -335,19 +314,19 @@ public class MethodeLinksBodyProcessor implements BodyProcessor {
 		removeTypeAttributeIfPresent(aTag);
 	}
 
-	private void removeTypeAttributeIfPresent(Node aTag) {
-		if (getAttribute(aTag, TYPE) != null) {
-			aTag.getAttributes().removeNamedItem(TYPE);
-		}
-	}
-
-	private boolean isSlideshowUrl(Node aTag) {
-		return getAttribute(aTag, TYPE) != null && getAttribute(aTag, TYPE).getNodeValue().equals("slideshow");
+    private boolean isSlideshowUrl(Node aTag) {
+        return getAttribute(aTag, TYPE) != null && getAttribute(aTag, TYPE).getNodeValue().equals("slideshow");
     }
 
-	private Node getAttribute(Node aTag, String attributeName) {
-		return aTag.getAttributes().getNamedItem(attributeName);
-	}
+    private void removeTypeAttributeIfPresent(Node aTag) {
+        if (getAttribute(aTag, TYPE) != null) {
+            aTag.getAttributes().removeNamedItem(TYPE);
+        }
+    }
+
+    private Node getAttribute(Node aTag, String attributeName) {
+        return aTag.getAttributes().getNamedItem(attributeName);
+    }
 
 	private Optional<String> extractUuid(Node node) {
         return extractUuid(getHref(node));
@@ -355,10 +334,10 @@ public class MethodeLinksBodyProcessor implements BodyProcessor {
 
     private Optional<String> extractUuid(String href) {
         Matcher matcher = UUID_REGEX_PATTERN.matcher(href);
-        if(matcher.matches()){
-            return Optional.fromNullable(matcher.group(1));
+        if (matcher.matches()) {
+            return Optional.ofNullable(matcher.group(1));
         }
-        return Optional.absent();
+        return Optional.empty();
     }
 
     private String getHref(Node aTag) {
@@ -366,11 +345,13 @@ public class MethodeLinksBodyProcessor implements BodyProcessor {
         final Node hrefAttr = attributes.getNamedItem("href");
         return hrefAttr == null ? "" : hrefAttr.getNodeValue();
     }
-    
-    /** Strips out a tag.
-     *  If the child content of the tag is empty or only whitespace, it is removed;
-     *  any other child content of the tag is preserved in place.
-     *  @param aTag the tag
+
+    /**
+     * Strips out a tag.
+     * If the child content of the tag is empty or only whitespace, it is removed;
+     * any other child content of the tag is preserved in place.
+     *
+     * @param aTag the tag
      */
     private void removeATag(Element aTag) {
     	Node parentNode = aTag.getParentNode();
@@ -385,22 +366,6 @@ public class MethodeLinksBodyProcessor implements BodyProcessor {
     	    }
     	}
         parentNode.removeChild(aTag);
-	}
-    
-    private Set<String> extractUuids(List<Node> aTagsToCheck) {
-        final List<String> uuids = new ArrayList<>(aTagsToCheck.size());
-
-        for (Node node : aTagsToCheck) {
-            Optional<String> optionalUuid = extractUuid(node);
-            if(optionalUuid.isPresent())
-				uuids.add(optionalUuid.get());
-        }
-
-        return new HashSet<>(uuids);
-    }
-
-    private boolean containsUuid(String href) {
-        return extractUuid(href).isPresent();
     }
 
     private DocumentBuilder getDocumentBuilder() throws ParserConfigurationException {
@@ -409,5 +374,4 @@ public class MethodeLinksBodyProcessor implements BodyProcessor {
 
         return documentBuilderFactory.newDocumentBuilder();
     }
-
 }

--- a/src/test/java/com/ft/methodearticlemapper/BodyProcessingStepDefs.java
+++ b/src/test/java/com/ft/methodearticlemapper/BodyProcessingStepDefs.java
@@ -9,6 +9,7 @@ import static org.hamcrest.text.IsEqualIgnoringCase.equalToIgnoringCase;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -25,7 +26,6 @@ import java.util.List;
 import java.util.Map;
 
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.UriBuilder;
 import javax.xml.namespace.QName;
 
 import org.apache.commons.lang.RandomStringUtils;
@@ -188,9 +188,11 @@ public class BodyProcessingStepDefs {
         when(concordanceApiClient.resource(URI.create(CONCORDANCE_URL + URLEncoder.encode(TME_ID_CONCORDED, "UTF-8") + "&identifierValue=" + TME_ID_NOT_CONCORDED))).thenReturn(webResource);
         when(webResource.accept(MediaType.APPLICATION_JSON_TYPE)).thenReturn(builder);
         when(webResource.header(anyString(), anyString())).thenReturn(builder);
+        when(builder.type(MediaType.APPLICATION_JSON_TYPE)).thenReturn(builder);
         when(builder.header(anyString(), anyString())).thenReturn(builder);
         when(builder.get(Concordances.class)).thenReturn(concordancesResponse);
         when(builder.get(ClientResponse.class)).thenReturn(clientResponse);
+        when(builder.post(eq(ClientResponse.class), anyObject())).thenReturn(clientResponse);
         when(clientResponse.getStatus()).thenReturn(200);
         when(clientResponse.getEntity(String.class)).thenReturn("[{\"uuid\":\"" + CONTENT_STORE_UUID + "\", \"type\": \"Article\"}]");
 

--- a/src/test/java/com/ft/methodearticlemapper/BodyProcessingStepDefs.java
+++ b/src/test/java/com/ft/methodearticlemapper/BodyProcessingStepDefs.java
@@ -102,6 +102,7 @@ public class BodyProcessingStepDefs {
 	private static final String TME_ID_NOT_CONCORDED = "notconcorded";
 	private static final URI CONCORDANCE_URL = URI.create("concordanceuri/concordances?authority=http%3A%2F%2Fapi.ft.com%2Fsystem%2FFT-TME&identifierValue=");
 	private static final String API_URL_CONCORDED ="http://api.ft.com/organisations/704a3225-9b5c-3b4f-93c7-8e6a6993bfb0";
+    private static final String CONTENT_STORE_UUID = "fbbee07f-5054-4a42-b596-64e0625d19a6";
     private static  final Identifier identifier = new Identifier(TME_AUTHORITY, TME_ID_CONCORDED);
     private static final  ConceptView concept= new ConceptView(API_URL_CONCORDED , API_URL_CONCORDED );
     private Concordance concordance;
@@ -145,8 +146,8 @@ public class BodyProcessingStepDefs {
         entity = new ByteArrayInputStream("Test".getBytes(StandardCharsets.UTF_8));
         registry = new MethodeBodyTransformationXMLEventHandlerRegistry(videoMatcher, interactiveGraphicsMatcher);
         concordance = new Concordance(concept, identifier);
-        concordancesResponse = new Concordances(Arrays.asList(concordance));  
-        concordancesEmpty = new Concordances(new ArrayList<Concordance>());
+        concordancesResponse = new Concordances(Collections.singletonList(concordance));
+        concordancesEmpty = new Concordances(new ArrayList<>());
 
         rulesAndHandlers = new HashMap<>();
         rulesAndHandlers.put( "STRIP ELEMENT AND CONTENTS" , "StripElementAndContentsXMLEventHandler");
@@ -170,30 +171,28 @@ public class BodyProcessingStepDefs {
         rulesAndHandlers.put( "WRAP AND TRANSFORM A INLINE IMAGE", "WrappedHandlerXmlEventHandler");
         rulesAndHandlers.put( "REPLACE BLOCK ELEMENT TAG", "SimpleTransformBlockElementEventHandler");
 
-
+        WebResource webResource = mock(WebResource.class);
         WebResource webResourceNotFound = mock(WebResource.class);
-        when(documentStoreApiClient.resource(any(URI.class))).thenReturn(webResourceNotFound);
+        WebResource.Builder builder = mock(WebResource.Builder.class);
         WebResource.Builder builderNotFound = mock(WebResource.Builder.class);
+        ClientResponse clientResponse = mock(ClientResponse.class);
+
+        when(concordanceApiClient.resource(URI.create(CONCORDANCE_URL + URLEncoder.encode(TME_ID_NOT_CONCORDED, "UTF-8")))).thenReturn(webResourceNotFound);
         when(webResourceNotFound.accept(any(MediaType[].class))).thenReturn(builderNotFound);
         when(builderNotFound.header(anyString(), anyObject())).thenReturn(builderNotFound);
         when(builderNotFound.get(ClientResponse.class)).thenReturn(clientResponseWithCode(404));
-        
-        WebResource webResource = mock(WebResource.class);
-        WebResource.Builder builder = mock(WebResource.Builder.class);
-        when(documentStoreApiClient.resource(UriBuilder.fromUri(documentStoreUri).path("fbbee07f-5054-4a42-b596-64e0625d19a6").build())).thenReturn(webResource);
-        when(concordanceApiClient.resource(URI.create(CONCORDANCE_URL+ URLEncoder.encode(TME_ID_CONCORDED, "UTF-8")))).thenReturn(webResource);
-        when(concordanceApiClient.resource(URI.create(CONCORDANCE_URL+ URLEncoder.encode(TME_ID_CONCORDED, "UTF-8")+"&identifierValue="+TME_ID_NOT_CONCORDED))).thenReturn(webResource);
-        when(builder.get(Concordances.class)).thenReturn(concordancesResponse);
-        when(concordanceApiClient.resource(URI.create(CONCORDANCE_URL+ URLEncoder.encode(TME_ID_NOT_CONCORDED, "UTF-8")))).thenReturn(webResourceNotFound);
         when(builderNotFound.get(Concordances.class)).thenReturn(concordancesEmpty);
+
+        when(documentStoreApiClient.resource(any(URI.class))).thenReturn(webResource);
+        when(concordanceApiClient.resource(URI.create(CONCORDANCE_URL + URLEncoder.encode(TME_ID_CONCORDED, "UTF-8")))).thenReturn(webResource);
+        when(concordanceApiClient.resource(URI.create(CONCORDANCE_URL + URLEncoder.encode(TME_ID_CONCORDED, "UTF-8") + "&identifierValue=" + TME_ID_NOT_CONCORDED))).thenReturn(webResource);
         when(webResource.accept(MediaType.APPLICATION_JSON_TYPE)).thenReturn(builder);
-        when(builder.header(anyString(), anyString())).thenReturn(builder);
         when(webResource.header(anyString(), anyString())).thenReturn(builder);
-        ClientResponse clientResponseSuccess = mock(ClientResponse.class);
-        when(builder.get(ClientResponse.class)).thenReturn(clientResponseSuccess);
-        InputStream inputStream = mock(InputStream.class);
-        when(clientResponseSuccess.getEntityInputStream()).thenReturn(inputStream);
-        when(clientResponseSuccess.getStatus()).thenReturn(200);
+        when(builder.header(anyString(), anyString())).thenReturn(builder);
+        when(builder.get(Concordances.class)).thenReturn(concordancesResponse);
+        when(builder.get(ClientResponse.class)).thenReturn(clientResponse);
+        when(clientResponse.getStatus()).thenReturn(200);
+        when(clientResponse.getEntity(String.class)).thenReturn("[{\"uuid\":\"" + CONTENT_STORE_UUID + "\", \"type\": \"Article\"}]");
 
         bodyTransformer = new BodyProcessingFieldTransformerFactory(documentStoreApiClient, documentStoreUri, videoMatcher, interactiveGraphicsMatcher, concordanceApiClient, concordanceUri).newInstance();
     }

--- a/src/test/java/com/ft/methodearticlemapper/transformation/BodyProcessingFieldTransformerFactoryTest.java
+++ b/src/test/java/com/ft/methodearticlemapper/transformation/BodyProcessingFieldTransformerFactoryTest.java
@@ -7,7 +7,9 @@ import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
@@ -94,8 +96,9 @@ public class BodyProcessingFieldTransformerFactoryTest {
                 documentStoreUri, videoMatcher, interactiveGraphicsMatcher, concordanceClient, concordanceUri ).newInstance();
 		when(documentStoreApiClient.resource((URI) any())).thenReturn(webResourceNotFound);
 		when(webResourceNotFound.accept(MediaType.APPLICATION_JSON_TYPE)).thenReturn(builderNotFound);
+		when(builderNotFound.type(MediaType.APPLICATION_JSON_TYPE)).thenReturn(builderNotFound);
 		when(builderNotFound.header(anyString(), anyString())).thenReturn(builderNotFound);
-		when(builderNotFound.get(ClientResponse.class)).thenReturn(clientResponse);
+		when(builderNotFound.post(eq(ClientResponse.class), anyObject())).thenReturn(clientResponse);
 		when(clientResponse.getStatus()).thenReturn(200);
 		when(clientResponse.getEntity(String.class)).thenReturn("[]");
 		when(concordanceClient.resource((URI) any())).thenReturn(webResourceNotFound);
@@ -107,8 +110,9 @@ public class BodyProcessingFieldTransformerFactoryTest {
     public void kitchenSinkArticleShouldBeTransformedAccordingToRules() {
 		when(documentStoreApiClient.resource(any(URI.class))).thenReturn(webResource);
         when(webResource.accept(MediaType.APPLICATION_JSON_TYPE)).thenReturn(builder);
-        when(builder.header(anyString(), anyString())).thenReturn(builder);
-        when(builder.get(ClientResponse.class)).thenReturn(clientResponse);
+		when(builder.type(MediaType.APPLICATION_JSON_TYPE)).thenReturn(builder);
+		when(builder.header(anyString(), anyString())).thenReturn(builder);
+		when(builder.post(eq(ClientResponse.class), anyObject())).thenReturn(clientResponse);
         when(clientResponse.getStatus()).thenReturn(200);
 		when(clientResponse.getEntity(String.class)).thenReturn("[{\"uuid\":\""
 				+ KITCHEN_SINK_ASSET1_UUID + "\", \"type\": \"Article\"}, {\"uuid\":\""

--- a/src/test/java/com/ft/methodearticlemapper/transformation/MethodeLinksBodyProcessorTest.java
+++ b/src/test/java/com/ft/methodearticlemapper/transformation/MethodeLinksBodyProcessorTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -52,9 +53,10 @@ public class MethodeLinksBodyProcessorTest {
 	public void setup() throws Exception {
 		bodyProcessor = new MethodeLinksBodyProcessor(documentStoreApiClient, new URI("www.document-store-api.com"));
 		when(documentStoreApiClient.resource(any(URI.class))).thenReturn(webResource);
-		when(webResource.accept(any(MediaType[].class))).thenReturn(builder);
+		when(webResource.accept(MediaType.APPLICATION_JSON_TYPE)).thenReturn(builder);
+		when(builder.type(MediaType.APPLICATION_JSON_TYPE)).thenReturn(builder);
 		when(builder.header(anyString(), anyObject())).thenReturn(builder);
-		when(builder.get(ClientResponse.class)).thenReturn(clientResponse);
+		when(builder.post(eq(ClientResponse.class), anyObject())).thenReturn(clientResponse);
 		when(clientResponse.getStatus()).thenReturn(200);
 		when(clientResponse.getEntity(String.class)).thenReturn("[]");
 	}
@@ -106,7 +108,7 @@ public class MethodeLinksBodyProcessorTest {
 
 	@Test(expected = BodyProcessingException.class)
 	public void shouldThrowBodyProcessingExceptionWhenDocumentStoreUnavailable() {
-		when(builder.get(ClientResponse.class)).thenThrow(clientHandlerException);
+		when(builder.post(eq(ClientResponse.class), anyObject())).thenThrow(clientHandlerException);
 		when(clientHandlerException.getCause()).thenReturn(new IOException());
 
 		String body = "<body><a href=\"" + uuid + "\" title=\"Some absurd text here\"> Link Text</a></body>";
@@ -115,7 +117,7 @@ public class MethodeLinksBodyProcessorTest {
 
 	@Test(expected = BodyProcessingException.class)
 	public void shouldThrowBodyProcessingExceptionWhenClientFailsToProcessTheRequestOrResponse() {
-		when(builder.get(ClientResponse.class)).thenThrow(clientHandlerException);
+		when(builder.post(eq(ClientResponse.class), anyObject())).thenThrow(clientHandlerException);
 
 		String body = "<body><a href=\"" + uuid + "\" title=\"Some absurd text here\"> Link Text</a></body>";
 		bodyProcessor.process(body, new DefaultTransactionIdBodyProcessingContext(TRANSACTION_ID));

--- a/src/test/java/com/ft/methodearticlemapper/transformation/MethodeLinksBodyProcessorTest.java
+++ b/src/test/java/com/ft/methodearticlemapper/transformation/MethodeLinksBodyProcessorTest.java
@@ -1,225 +1,343 @@
 package com.ft.methodearticlemapper.transformation;
 
+import com.ft.bodyprocessing.BodyProcessingContext;
+import com.ft.bodyprocessing.BodyProcessingException;
 import com.ft.bodyprocessing.DefaultTransactionIdBodyProcessingContext;
 import com.ft.jerseyhttpwrapper.ResilientClient;
-import com.ft.methodearticlemapper.exception.DocumentStoreApiUnavailableException;
-import com.ft.methodearticlemapper.model.EomAssetType;
 import com.sun.jersey.api.client.ClientHandlerException;
 import com.sun.jersey.api.client.ClientResponse;
 import com.sun.jersey.api.client.WebResource;
-import com.sun.jersey.core.header.InBoundHeaders;
-import com.sun.jersey.spi.MessageBodyWorkers;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
-
 import javax.ws.rs.core.MediaType;
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URI;
-import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.UUID;
 
 import static com.ft.methodetesting.xml.XmlMatcher.identicalXmlTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class MethodeLinksBodyProcessorTest {
 
+	private static final String TRANSACTION_ID = "tid_test";
+
 	@Mock
 	private ResilientClient documentStoreApiClient;
-
-	@Mock
-	private InBoundHeaders headers;
-	@Mock
-	private MessageBodyWorkers workers;
 	@Mock
 	private WebResource.Builder builder;
-    @Mock
-    private ClientHandlerException clientHandlerException;
+	@Mock
+	private ClientHandlerException clientHandlerException;
+	@Mock
+	private ClientResponse clientResponse;
+	@Mock
+	private BodyProcessingContext bodyProcessingContext;
+	@Mock
+	private WebResource webResource;
 
-    private URI uri;
-	private InputStream entity;
+	private String uuid = UUID.randomUUID().toString();
+	private MethodeLinksBodyProcessor bodyProcessor;
 
 	@Before
 	public void setup() throws Exception {
-        uri = new URI("www.anyuri.com");
-		entity = new ByteArrayInputStream("Test".getBytes(StandardCharsets.UTF_8));
-		WebResource webResource = mock(WebResource.class);
+		bodyProcessor = new MethodeLinksBodyProcessor(documentStoreApiClient, new URI("www.document-store-api.com"));
 		when(documentStoreApiClient.resource(any(URI.class))).thenReturn(webResource);
 		when(webResource.accept(any(MediaType[].class))).thenReturn(builder);
 		when(builder.header(anyString(), anyObject())).thenReturn(builder);
-		when(builder.get(ClientResponse.class)).thenReturn(clientResponseWithCode(404));
+		when(builder.get(ClientResponse.class)).thenReturn(clientResponse);
+		when(clientResponse.getStatus()).thenReturn(200);
+		when(clientResponse.getEntity(String.class)).thenReturn("[]");
 	}
 
-	private MethodeLinksBodyProcessor bodyProcessor;
-	
-	private String uuid = UUID.randomUUID().toString();
-	private static final String TRANSACTION_ID = "tid_test";
-
-    @Test(expected = DocumentStoreApiUnavailableException.class)
-    public void shouldThrowDocumentStoreApiNotAvailable(){
-        bodyProcessor = new MethodeLinksBodyProcessor(documentStoreApiClient, uri);
-        when(builder.get(ClientResponse.class)).thenThrow(clientHandlerException);
-        when(clientHandlerException.getCause()).thenReturn(new IOException());
-
-        String body = "<body><a href=\"http://www.ft.com/cms/s/" + uuid + ".html\" title=\"Some absurd text here\"> Link Text</a></body>";
-        bodyProcessor.process(body, new DefaultTransactionIdBodyProcessingContext(TRANSACTION_ID));
-    }
-
-    @Test(expected = DocumentStoreApiUnavailableException.class)
-    public void shouldThrowDocumentStoreApiNotAvailableFor5XX(){
-        bodyProcessor = new MethodeLinksBodyProcessor(documentStoreApiClient, uri);
-        when(builder.get(ClientResponse.class)).thenReturn(clientResponseWithCode(503));
-
-        String body = "<body><a href=\"http://www.ft.com/cms/s/" + uuid + ".html\" title=\"Some absurd text here\"> Link Text</a></body>";
-        bodyProcessor.process(body, new DefaultTransactionIdBodyProcessingContext(TRANSACTION_ID));
-    }
+	@Test
+	public void shouldReturnUnchangedBodyIfBodyIsNull() {
+		String processedBody = bodyProcessor.process(null, new DefaultTransactionIdBodyProcessingContext(TRANSACTION_ID));
+		assertThat(processedBody, is(nullValue()));
+	}
 
 	@Test
-	public void shouldReplaceNodeWhenItsALinkThatWillBeInTheContentStoreWhenAvailableInContentStore(){
-		bodyProcessor = new MethodeLinksBodyProcessor(documentStoreApiClient, uri);
-		when(builder.get(ClientResponse.class)).thenReturn(clientResponseWithCode(200));
+	public void shouldReturnUnchangedBodyIfBodyIsEmpty() {
+		String processedBody = bodyProcessor.process("", new DefaultTransactionIdBodyProcessingContext(TRANSACTION_ID));
+		assertThat(processedBody, is(""));
+	}
 
+	@Test
+	public void shouldReturnUnchangedBodyIfBodyIsWhitespace() {
+		String processedBody = bodyProcessor.process(" ", new DefaultTransactionIdBodyProcessingContext(TRANSACTION_ID));
+		assertThat(processedBody, is(" "));
+	}
+
+	@Test(expected = BodyProcessingException.class)
+	public void shouldThrowBodyProcessingExceptionWhenTransactionIdIsNull() {
+		when(clientResponse.getStatus()).thenReturn(200);
+		when(clientResponse.getEntity(String.class)).thenReturn("[{\"uuid\":\"" + uuid + "\", \"type\": \"Article\"}]");
+
+		String body = "<body><a href=\"http://www.url.com/" + uuid + "\" title=\"Some absurd text here\"> Link Text</a></body>";
+		bodyProcessor.process(body, new DefaultTransactionIdBodyProcessingContext(null));
+	}
+
+	@Test(expected = BodyProcessingException.class)
+	public void shouldThrowBodyProcessingExceptionWhenTransactionIdIsEmpty() {
+		when(clientResponse.getStatus()).thenReturn(200);
+		when(clientResponse.getEntity(String.class)).thenReturn("[{\"uuid\":\"" + uuid + "\", \"type\": \"Article\"}]");
+
+		String body = "<body><a href=\"http://www.url.com/" + uuid + "\" title=\"Some absurd text here\"> Link Text</a></body>";
+		bodyProcessor.process(body, new DefaultTransactionIdBodyProcessingContext(" "));
+	}
+
+	@Test(expected = BodyProcessingException.class)
+	public void shouldThrowBodyProcessingExceptionWhenBodyProcessingContextIsOfWrongType() {
+		when(clientResponse.getStatus()).thenReturn(200);
+		when(clientResponse.getEntity(String.class)).thenReturn("[{\"uuid\":\"" + uuid + "\", \"type\": \"Article\"}]");
+
+		String body = "<body><a href=\"http://www.url.com/" + uuid + "\" title=\"Some absurd text here\"> Link Text</a></body>";
+		bodyProcessor.process(body, bodyProcessingContext);
+	}
+
+	@Test(expected = BodyProcessingException.class)
+	public void shouldThrowBodyProcessingExceptionWhenDocumentStoreUnavailable() {
+		when(builder.get(ClientResponse.class)).thenThrow(clientHandlerException);
+		when(clientHandlerException.getCause()).thenReturn(new IOException());
+
+		String body = "<body><a href=\"" + uuid + "\" title=\"Some absurd text here\"> Link Text</a></body>";
+		bodyProcessor.process(body, new DefaultTransactionIdBodyProcessingContext(TRANSACTION_ID));
+	}
+
+	@Test(expected = BodyProcessingException.class)
+	public void shouldThrowBodyProcessingExceptionWhenClientFailsToProcessTheRequestOrResponse() {
+		when(builder.get(ClientResponse.class)).thenThrow(clientHandlerException);
+
+		String body = "<body><a href=\"" + uuid + "\" title=\"Some absurd text here\"> Link Text</a></body>";
+		bodyProcessor.process(body, new DefaultTransactionIdBodyProcessingContext(TRANSACTION_ID));
+	}
+
+	@Test(expected = BodyProcessingException.class)
+	public void shouldThrowBodyProcessingExceptionWhenDocumentStoreReturns5XX() {
+		when(clientResponse.getStatus()).thenReturn(503);
+
+		String body = "<body><a href=\"" + uuid + "\" title=\"Some absurd text here\"> Link Text</a></body>";
+		bodyProcessor.process(body, new DefaultTransactionIdBodyProcessingContext(TRANSACTION_ID));
+	}
+
+	@Test(expected = BodyProcessingException.class)
+	public void shouldThrowBodyProcessingExceptionWhenDocumentStoreReturns4XX() {
+		when(clientResponse.getStatus()).thenReturn(404);
+
+		String body = "<body><a href=\"" + uuid + "\" title=\"Some absurd text here\"> Link Text</a></body>";
+		bodyProcessor.process(body, new DefaultTransactionIdBodyProcessingContext(TRANSACTION_ID));
+	}
+
+	@Test(expected = BodyProcessingException.class)
+	public void shouldThrowBodyProcessingExceptionForFailureToParseJsonFromDocumentStore() {
+		when(clientResponse.getStatus()).thenReturn(200);
+		when(clientResponse.getEntity(String.class)).thenReturn("Not a json");
+
+		String body = "<body><a href=\"" + uuid + "\" title=\"Some absurd text here\"> Link Text</a></body>";
+		bodyProcessor.process(body, new DefaultTransactionIdBodyProcessingContext(TRANSACTION_ID));
+	}
+
+	@Test
+	public void shouldReplaceNodeWhenHrefContainsUuidPresentInDocumentStore() {
+		when(clientResponse.getStatus()).thenReturn(200);
+		when(clientResponse.getEntity(String.class)).thenReturn("[{\"uuid\":\"" + uuid + "\", \"type\": \"Article\"}]");
+
+		String body = "<body><a href=\"http://www.url.com/" + uuid + "\" title=\"Some absurd text here\"> Link Text</a></body>";
+		String processedBody = bodyProcessor.process(body, new DefaultTransactionIdBodyProcessingContext(TRANSACTION_ID));
+
+		assertThat(processedBody, is(identicalXmlTo("<body><content id=\"" + uuid + "\" title=\"Some absurd text here\" type=\"" + MethodeLinksBodyProcessor.BASE_CONTENT_TYPE + "Article\"> Link Text</content></body>")));
+	}
+
+	@Test
+	public void shouldSetContentTypeToDefaultValueWhenTypeIsMissingFromDocumentStoreResponse() {
+		when(clientResponse.getStatus()).thenReturn(200);
+		when(clientResponse.getEntity(String.class)).thenReturn("[{\"uuid\":\"" + uuid + "\"}]");
+
+		String body = "<body><a href=\"http://www.url.com/" + uuid + "\" title=\"Some absurd text here\"> Link Text</a></body>";
+		String processedBody = bodyProcessor.process(body, new DefaultTransactionIdBodyProcessingContext(TRANSACTION_ID));
+
+		assertThat(processedBody, is(identicalXmlTo("<body><content id=\"" + uuid + "\" title=\"Some absurd text here\" type=\"" + MethodeLinksBodyProcessor.DEFAULT_CONTENT_TYPE + "\"> Link Text</content></body>")));
+	}
+
+	@Test
+	public void shouldReplaceNodeWhenHrefContainsOnlyUuidPresentInDocumentStore() {
+		when(clientResponse.getStatus()).thenReturn(200);
+		when(clientResponse.getEntity(String.class)).thenReturn("[{\"uuid\":\"" + uuid + "\", \"type\": \"Article\"}]");
+
+		String body = "<body><a href=\"" + uuid + "\" title=\"Some absurd text here\"> Link Text</a></body>";
+		String processedBody = bodyProcessor.process(body, new DefaultTransactionIdBodyProcessingContext(TRANSACTION_ID));
+
+		assertThat(processedBody, is(identicalXmlTo("<body><content id=\"" + uuid + "\" title=\"Some absurd text here\" type=\"" + MethodeLinksBodyProcessor.BASE_CONTENT_TYPE + "Article\"> Link Text</content></body>")));
+	}
+
+	@Test
+	public void shouldReplaceNodeAndNotAddTitleIfTitleIsMissing() {
+		when(clientResponse.getStatus()).thenReturn(200);
+		when(clientResponse.getEntity(String.class)).thenReturn("[{\"uuid\":\"" + uuid + "\", \"type\": \"Article\"}]");
+
+		String body = "<body><a href=\"" + uuid + "\"> Link Text</a></body>";
+		String processedBody = bodyProcessor.process(body, new DefaultTransactionIdBodyProcessingContext(TRANSACTION_ID));
+
+		assertThat(processedBody, is(identicalXmlTo("<body><content id=\"" + uuid + "\" type=\"" + MethodeLinksBodyProcessor.BASE_CONTENT_TYPE + "Article\"> Link Text</content></body>")));
+	}
+
+	@Test
+	public void shouldReplaceNodeWhenHrefContainsMethodePathWithUuidPresentInDocumentStore() {
+		when(clientResponse.getStatus()).thenReturn(200);
+		when(clientResponse.getEntity(String.class)).thenReturn("[{\"uuid\":\"" + uuid + "\", \"type\": \"Article\"}]");
+
+		String body = "<body><a href=\"/Content/2007/Path/To/Methode/Article.xml?uuid=" + uuid + "\" title=\"Some absurd text here\"> Link Text</a></body>";
+		String processedBody = bodyProcessor.process(body, new DefaultTransactionIdBodyProcessingContext(TRANSACTION_ID));
+
+		assertThat(processedBody, is(identicalXmlTo("<body><content id=\"" + uuid + "\" title=\"Some absurd text here\" type=\"" + MethodeLinksBodyProcessor.BASE_CONTENT_TYPE + "Article\"> Link Text</content></body>")));
+	}
+
+	@Test
+	public void shouldNotReplaceNodeWhenItsALinkThatWillNotBeInTheDocumentStore() {
 		String body = "<body><a href=\"http://www.ft.com/cms/s/" + uuid + ".html\" title=\"Some absurd text here\"> Link Text</a></body>";
 		String processedBody = bodyProcessor.process(body, new DefaultTransactionIdBodyProcessingContext(TRANSACTION_ID));
-		assertThat(processedBody, is(identicalXmlTo("<body><content id=\"" + uuid + "\" title=\"Some absurd text here\" type=\"" + MethodeLinksBodyProcessor.ARTICLE_TYPE + "\"> Link Text</content></body>")));
+
+		assertThat(processedBody, is(identicalXmlTo("<body><a href=\"http://www.ft.com/cms/s/" + uuid + ".html\" title=\"Some absurd text here\"> Link Text</a></body>")));
 	}
 
 	@Test
-	public void shouldNotReplaceNodeWhenItsALinkThatWillNotBeInTheContentStore(){
-		Map<String, EomAssetType> assetTypes = new HashMap<>();
-		assetTypes.put(uuid, new EomAssetType.Builder().type("Slideshow").uuid(uuid).build());
-		bodyProcessor = new MethodeLinksBodyProcessor(documentStoreApiClient, uri);
-		
-		String body = "<body><a href=\"http://www.ft.com/cms/s/" + uuid + ".html\" title=\"Some absurd text here\"> Link Text</a></body>";
-		String processedBody = bodyProcessor.process(body, new DefaultTransactionIdBodyProcessingContext(TRANSACTION_ID));
-        assertThat(processedBody, is(identicalXmlTo("<body><a href=\"http://www.ft.com/cms/s/" + uuid + ".html\" title=\"Some absurd text here\"> Link Text</a></body>")));
-	}
-	
-	@Test
-	public void shouldNotTransformAPDFLinkIntoAnInternalLink() {
-		Map<String, EomAssetType> assetTypes = new HashMap<>();
-		assetTypes.put("add666f2-cd78-11e4-a15a-00144feab7de", new EomAssetType.Builder().type("Pdf").uuid("add666f2-cd78-11e4-a15a-00144feab7de").build());
-		bodyProcessor = new MethodeLinksBodyProcessor(documentStoreApiClient, uri);
-		String body = "<body><a href=\"http://im.ft-static.com/content/images/add666f2-cd78-11e4-a15a-00144feab7de.pdf\" title=\"im.ft-static.com\">Budget 2015</a></body>";
-		String processedBody = bodyProcessor.process(body, new DefaultTransactionIdBodyProcessingContext(TRANSACTION_ID));
-		assertThat(processedBody, is(identicalXmlTo("<body><a href=\"http://im.ft-static.com/content/images/add666f2-cd78-11e4-a15a-00144feab7de.pdf\" title=\"im.ft-static.com\">Budget 2015</a></body>")));
-	}
-	
-	@Test
-	public void shouldStripIntlFromHrefValueWhenItsNotAValidInternalLink(){
-		Map<String, EomAssetType> assetTypes = new HashMap<>();
-		assetTypes.put(uuid, new EomAssetType.Builder().type("Slideshow").uuid(uuid).build());
-		bodyProcessor = new MethodeLinksBodyProcessor(documentStoreApiClient, uri);
-		
+	public void shouldStripIntlFromHrefValueWhenItsALinkThatWillNotBeInTheDocumentStore() {
 		String body = "<body><a href=\"http://www.ft.com/intl/cms/s/" + uuid + ".html\" title=\"Some absurd text here\"> Link Text</a></body>";
 		String processedBody = bodyProcessor.process(body, new DefaultTransactionIdBodyProcessingContext(TRANSACTION_ID));
-        assertThat(processedBody, is(identicalXmlTo("<body><a href=\"http://www.ft.com/cms/s/" + uuid + ".html\" title=\"Some absurd text here\"> Link Text</a></body>")));
-	}
-	
-	@Test
-	public void shouldStripParamFromHrefValueWhenItsNotAValidInternalLink(){
-		Map<String, EomAssetType> assetTypes = new HashMap<>();
-		assetTypes.put(uuid, new EomAssetType.Builder().type("Slideshow").uuid(uuid).build());
-		bodyProcessor = new MethodeLinksBodyProcessor(documentStoreApiClient, uri);
-		
-		String body = "<body><a href=\"http://www.ft.com/cms/s/" + uuid + ".html?param=5\" title=\"Some absurd text here\"> Link Text</a></body>";
-		String processedBody = bodyProcessor.process(body, new DefaultTransactionIdBodyProcessingContext(TRANSACTION_ID));
-        assertThat(processedBody, is(identicalXmlTo("<body><a href=\"http://www.ft.com/cms/s/" + uuid + ".html\" title=\"Some absurd text here\"> Link Text</a></body>")));
-	}
-	
-	@Test
-	public void shouldRemoveNodeIfATagHasNoHrefAttributeForNonInternalLinks() {
-		bodyProcessor = new MethodeLinksBodyProcessor(documentStoreApiClient, uri);
-		
-		String body = "<body><a title=\"Some absurd text here\">Link Text</a></body>";
-		String processedBody = bodyProcessor.process(body, new DefaultTransactionIdBodyProcessingContext(TRANSACTION_ID));
-        assertThat(processedBody, is(identicalXmlTo("<body>Link Text</body>")));
+
+		assertThat(processedBody, is(identicalXmlTo("<body><a href=\"http://www.ft.com/cms/s/" + uuid + ".html\" title=\"Some absurd text here\"> Link Text</a></body>")));
 	}
 
 	@Test
-	public void shouldRemoveNodeIfATagHasNoHrefAttributeForNonInternalLinksWithPreservingAllItsChildren() {
-		bodyProcessor = new MethodeLinksBodyProcessor(documentStoreApiClient, uri);
-
-		String body = "<body><a title=\"Some absurd text here\"><strong>first child</strong> Second child</a></body>";
-		String processedBody = bodyProcessor.process(body, new DefaultTransactionIdBodyProcessingContext(TRANSACTION_ID));
-        assertThat(processedBody, is(identicalXmlTo("<body><strong>first child</strong> Second child</body>")));
-	}
-	
-	@Test
-	public void shouldRemoveNodeIfATagHasNoHrefAttributeForNonInternalLinksEvenIfNodeEmpty() {
-		bodyProcessor = new MethodeLinksBodyProcessor(documentStoreApiClient, uri);
-		
-		String body = "<body><a title=\"Some absurd text here\"/></body>";
-		String processedBody = bodyProcessor.process(body, new DefaultTransactionIdBodyProcessingContext(TRANSACTION_ID));
-        assertThat(processedBody, is(identicalXmlTo("<body></body>")));
-	}
-	
-	@Test
-	public void shouldConvertNonArticlePathBasedInternalLinksToFullFledgedWebsiteLinks(){
-		Map<String, EomAssetType> assetTypes = new HashMap<>();
-		assetTypes.put(uuid, new EomAssetType.Builder().type("EOM::MediaGallery").uuid(uuid).build());
-		bodyProcessor = new MethodeLinksBodyProcessor(documentStoreApiClient, uri);
-		
+	public void shouldConvertMethodeLinksWhenItsALinkThatWillNotBeInTheDocumentStoreToFullFledgedWebsiteLinks() {
 		String body = "<body><a href=\"/FT Production/Slideshows/gallery.xml;uuid=" + uuid + "\" title=\"Some absurd text here\"> Link Text</a></body>";
 		String processedBody = bodyProcessor.process(body, new DefaultTransactionIdBodyProcessingContext(TRANSACTION_ID));
-        assertThat(processedBody, is(identicalXmlTo("<body><a href=\"http://www.ft.com/cms/s/" + uuid + ".html\" title=\"Some absurd text here\"> Link Text</a></body>")));
+
+		assertThat(processedBody, is(identicalXmlTo("<body><a href=\"http://www.ft.com/cms/s/" + uuid + ".html\" title=\"Some absurd text here\"> Link Text</a></body>")));
 	}
-    
-    @Test
-    public void thatWhitespaceOnlyLinksAreRemoved() {
-        bodyProcessor = new MethodeLinksBodyProcessor(documentStoreApiClient, uri);
-        
-        String body = "<body>Foo <a href=\"http://www.ft.com/intl/cms/s/0/12345.html\" title=\"Test link containing only whitespace\">\n</a> bar</body>";
-        
-        String processedBody = bodyProcessor.process(body, new DefaultTransactionIdBodyProcessingContext(TRANSACTION_ID));
-        assertThat(processedBody, is(identicalXmlTo("<body>Foo  bar</body>")));
-    }
-    
-    @Test
-    public void thatWhitespaceAndChildTagsOnlyLinksArePreserved() {
-        bodyProcessor = new MethodeLinksBodyProcessor(documentStoreApiClient, uri);
-        
-        String body = "<body>Foo <a href=\"http://www.ft.com/intl/cms/s/0/12345.html\" title=\"Test link with tag content\"><img src=\"http://localhost/\"/>\n</a> bar</body>";
-        
-        String processedBody = bodyProcessor.process(body, new DefaultTransactionIdBodyProcessingContext(TRANSACTION_ID));
-        assertThat(processedBody, is(identicalXmlTo(body)));
-    }
-    
-    @Test
-    public void thatEmptyLinksWithDataAttributesArePreserved() {
-        bodyProcessor = new MethodeLinksBodyProcessor(documentStoreApiClient, uri);
-        
-        String body = "<body>Foo <a data-asset-type=\"slideshow\" data-embedded=\"true\" href=\"http://www.ft.com/intl/cms/s/0/12345.html\" title=\"Test link with tag content\"></a> bar</body>";
-        
-        String processedBody = bodyProcessor.process(body, new DefaultTransactionIdBodyProcessingContext(TRANSACTION_ID));
-        assertThat(processedBody, is(identicalXmlTo(body)));
-    }
-    
-    @Test
-    public void thatEmptyLinksWithinPromoBoxesArePreserved() {
-        bodyProcessor = new MethodeLinksBodyProcessor(documentStoreApiClient, uri);
-        
-        String body = "<body>Foo <promo-box><promo-link><p><a title=\"Test Promo Link\" href=\"http://www.ft.com/cms/s/0/0bdf4bb6-6676-11e4-8bf6-00144feabdc0.html\"/></p></promo-link></promo-box> bar</body>";
-        
-        String processedBody = bodyProcessor.process(body, new DefaultTransactionIdBodyProcessingContext(TRANSACTION_ID));
-        assertThat(processedBody, is(identicalXmlTo(body)));
-    }
-    
-	private ClientResponse clientResponseWithCode(int status) {
-		return new ClientResponse(status, headers, entity, workers);
+
+	@Test
+	public void shouldReplaceNodeWhenHrefContainsExternalLinkWithUuidPresentInDocumentStore() {
+		when(clientResponse.getStatus()).thenReturn(200);
+		when(clientResponse.getEntity(String.class)).thenReturn("[{\"uuid\":\"" + uuid + "\", \"type\": \"Article\"}]");
+
+		String body = "<body><a href=\"http://www.external.com/" + uuid + "\"> Link Text</a></body>";
+		String processedBody = bodyProcessor.process(body, new DefaultTransactionIdBodyProcessingContext(TRANSACTION_ID));
+
+		assertThat(processedBody, is(identicalXmlTo("<body><content id=\"" + uuid + "\" type=\"" + MethodeLinksBodyProcessor.BASE_CONTENT_TYPE + "Article\"> Link Text</content></body>")));
 	}
+
+	@Test
+	public void shouldPreserveExternalLinksWithUuidThatWillNotBePresentDocumentStore() {
+		String body = "<body><a href=\"http://www.external.com/" + uuid + "\" title=\"Some absurd text here\"> Link Text</a></body>";
+		String processedBody = bodyProcessor.process(body, new DefaultTransactionIdBodyProcessingContext(TRANSACTION_ID));
+
+		assertThat(processedBody, is(identicalXmlTo("<body><a href=\"http://www.external.com/" + uuid + "\" title=\"Some absurd text here\"> Link Text</a></body>")));
+	}
+
+	@Test
+	public void shouldPreserveSlideshowLinksAndStripTypeAttribute() {
+		String body = "<body><a href=\"http://www.ft.com/content" + uuid + "\" type=\"slideshow\"> Link Text</a></body>";
+		String processedBody = bodyProcessor.process(body, new DefaultTransactionIdBodyProcessingContext(TRANSACTION_ID));
+
+		assertThat(processedBody, is(identicalXmlTo("<body><a href=\"http://www.ft.com/content" + uuid + "\"> Link Text</a></body>")));
+	}
+
+	@Test
+	public void shouldRemoveTypeAttributeFromInternalLinks() {
+		String body = "<body><a href=\"http://www.ft.com/content/" + uuid + "\" type=\"some-type\"> Link Text</a></body>";
+		String processedBody = bodyProcessor.process(body, new DefaultTransactionIdBodyProcessingContext(TRANSACTION_ID));
+
+		assertThat(processedBody, is(identicalXmlTo("<body><a href=\"http://www.ft.com/content/" + uuid + "\"> Link Text</a></body>")));
+	}
+
+	@Test
+	public void shouldRemoveNodeIfATagHasNoHrefAttribute() {
+		String body = "<body><a title=\"Some absurd text here\">Link Text</a></body>";
+		String processedBody = bodyProcessor.process(body, new DefaultTransactionIdBodyProcessingContext(TRANSACTION_ID));
+
+		assertThat(processedBody, is(identicalXmlTo("<body>Link Text</body>")));
+	}
+
+	@Test
+	public void shouldRemoveNodeIfATagHasHrefThatStartsWithAnchorPrefix() {
+		String body = "<body><a href=\"#http://www.ft.com/content/add666f2-cd78-11e4-a15a-00144feab7de\" title=\"Some absurd text here\">Link Text</a></body>";
+		String processedBody = bodyProcessor.process(body, new DefaultTransactionIdBodyProcessingContext(TRANSACTION_ID));
+
+		assertThat(processedBody, is(identicalXmlTo("<body>Link Text</body>")));
+	}
+
+	@Test
+	public void shouldRemoveNodeIfATagHasNoHrefAttributeWhilePreservingAllItsChildren() {
+		String body = "<body><a title=\"Some absurd text here\"><strong>first child</strong> Second child <![CDATA[CDATASection]]></a></body>";
+		String processedBody = bodyProcessor.process(body, new DefaultTransactionIdBodyProcessingContext(TRANSACTION_ID));
+
+		assertThat(processedBody, is(identicalXmlTo("<body><strong>first child</strong> Second child <![CDATA[CDATASection]]></body>")));
+	}
+
+	@Test
+	public void shouldRemoveNodeIfATagHasNoHrefAttributeWhilePreservingText() {
+		String body = "<body><a title=\"Some absurd text here\">Some text</a></body>";
+		String processedBody = bodyProcessor.process(body, new DefaultTransactionIdBodyProcessingContext(TRANSACTION_ID));
+
+		assertThat(processedBody, is(identicalXmlTo("<body>Some text</body>")));
+	}
+
+	@Test
+	public void thatWhitespaceOnlyLinksAreRemoved() {
+		String body = "<body>Foo <a href=\"http://www.ft.com/intl/cms/s/0/12345.html\" title=\"Test link containing only whitespace\">\n</a> bar</body>";
+		String processedBody = bodyProcessor.process(body, new DefaultTransactionIdBodyProcessingContext(TRANSACTION_ID));
+
+		assertThat(processedBody, is(identicalXmlTo("<body>Foo  bar</body>")));
+	}
+
+	@Test
+	public void thatCommentOnlyLinksAreRemoved() {
+		String body = "<body><a href=\"http://www.ft.com/intl/cms/s/0/12345.html\" title=\"Test link containing only comments\"><!-- Comment --></a></body>";
+		String processedBody = bodyProcessor.process(body, new DefaultTransactionIdBodyProcessingContext(TRANSACTION_ID));
+
+		assertThat(processedBody, is(identicalXmlTo("<body></body>")));
+	}
+
+	@Test
+	public void thatEmptyLinksWithDataAttributesArePreserved() {
+		String body = "<body>Foo <a data-asset-type=\"slideshow\" data-embedded=\"true\" href=\"http://www.ft.com/intl/cms/s/0/12345.html\" title=\"Test link with tag content\"></a> bar</body>";
+		String processedBody = bodyProcessor.process(body, new DefaultTransactionIdBodyProcessingContext(TRANSACTION_ID));
+
+		assertThat(processedBody, is(identicalXmlTo(body)));
+	}
+
+	@Test
+	public void thatWhitespaceAndChildTagsOnlyLinksArePreserved() {
+		String body = "<body>Foo <a href=\"http://www.ft.com/intl/cms/s/0/12345.html\" title=\"Test link with tag content\"><img src=\"http://localhost/\"/>\n</a> bar</body>";
+		String processedBody = bodyProcessor.process(body, new DefaultTransactionIdBodyProcessingContext(TRANSACTION_ID));
+
+		assertThat(processedBody, is(identicalXmlTo(body)));
+	}
+
+	@Test
+	public void thatCDATASectionOnlyLinksArePreserved() {
+		String body = "<body><a title=\"Some absurd text here\"><![CDATA[CDATASection]]></a></body>";
+		String processedBody = bodyProcessor.process(body, new DefaultTransactionIdBodyProcessingContext(TRANSACTION_ID));
+
+		assertThat(processedBody, is(identicalXmlTo("<body><![CDATA[CDATASection]]></body>")));
+	}
+
+	@Test
+	public void thatEmptyLinksWithinPromoBoxesArePreserved() {
+		String body = "<body>Foo <promo-box><promo-link><p><a title=\"Test Promo Link\" href=\"http://www.ft.com/cms/s/0/0bdf4bb6-6676-11e4-8bf6-00144feabdc0.html\"/></p></promo-link></promo-box> bar</body>";
+		String processedBody = bodyProcessor.process(body, new DefaultTransactionIdBodyProcessingContext(TRANSACTION_ID));
+
+		assertThat(processedBody, is(identicalXmlTo(body)));
+	}
+
 }


### PR DESCRIPTION
- internal links will now have their type set dynamically.
- only one request is made to document-store-api for all the uuids inside an
a tags.