### PR TITLE
Add alternativeStandfirsts field to content

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
         <dependency>
             <groupId>com.github.Financial-Times</groupId>
             <artifactId>content-model</artifactId>
-            <version>0.3.0-fd-rc2</version>
+            <version>0.3.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.hibernate</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
         <dependency>
             <groupId>com.github.Financial-Times</groupId>
             <artifactId>content-model</artifactId>
-            <version>0.1.47</version>
+            <version>0.3.0-fd-rc2</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.hibernate</groupId>

--- a/src/main/java/com/ft/methodearticlemapper/transformation/EomFileProcessor.java
+++ b/src/main/java/com/ft/methodearticlemapper/transformation/EomFileProcessor.java
@@ -1,12 +1,8 @@
 package com.ft.methodearticlemapper.transformation;
 
 import com.ft.bodyprocessing.BodyProcessor;
-import com.ft.content.model.AlternativeStandfirsts;
-import com.ft.uuidutils.DeriveUUID;
-import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableSortedSet;
-
 import com.ft.content.model.AccessLevel;
+import com.ft.content.model.AlternativeStandfirsts;
 import com.ft.content.model.AlternativeTitles;
 import com.ft.content.model.Brand;
 import com.ft.content.model.Comments;
@@ -20,9 +16,10 @@ import com.ft.methodearticlemapper.exception.UntransformableMethodeContentExcept
 import com.ft.methodearticlemapper.methode.ContentSource;
 import com.ft.methodearticlemapper.model.EomFile;
 import com.ft.methodearticlemapper.transformation.eligibility.PublishEligibilityChecker;
-
+import com.ft.uuidutils.DeriveUUID;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Maps;
-import java.util.Map.Entry;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,19 +28,6 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
-
-import java.io.IOException;
-import java.io.StringReader;
-import java.io.StringWriter;
-import java.text.DateFormat;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Collections;
-import java.util.Date;
-import java.util.Map;
-import java.util.TimeZone;
-import java.util.TreeSet;
-import java.util.UUID;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -58,6 +42,19 @@ import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
+import java.io.IOException;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.TimeZone;
+import java.util.TreeSet;
+import java.util.UUID;
 
 import static com.ft.uuidutils.DeriveUUID.Salts.IMAGE_SET;
 
@@ -199,10 +196,7 @@ public class EomFileProcessor {
         final String description = getDescription(type, xpath, value);
         final String contentPackage = getContentPackage(type, xpath, value, uuid);
         final Distribution canBeDistributed = getCanBeDistributed(eomFile.getContentSource(), type);
-
-        final AlternativeStandfirsts alternativeStandfirsts = AlternativeStandfirsts.builder()
-                .withPromotionalStandfirst(Strings.nullToEmpty(xpath.evaluate(PROMOTIONAL_STANDFIRST_XPATH, value)).trim())
-                .build();
+        final AlternativeStandfirsts alternativeStandfirsts = buildAlternativeStandfirsts(xpath, value);
 
         return Content.builder()
                 .withUuid(uuid)
@@ -491,5 +485,14 @@ public class EomFileProcessor {
             default:
                 return Distribution.VERIFY;
         }
+    }
+
+    private AlternativeStandfirsts buildAlternativeStandfirsts(XPath xpath, Document value) throws XPathExpressionException {
+        AlternativeStandfirsts.Builder builder = AlternativeStandfirsts.builder();
+        String promotionalStandfirst = Strings.nullToEmpty(xpath.evaluate(PROMOTIONAL_STANDFIRST_XPATH, value)).trim();
+        if (!promotionalStandfirst.isEmpty()) {
+            builder = builder.withPromotionalStandfirst(promotionalStandfirst);
+        }
+        return builder.build();
     }
 }

--- a/src/main/java/com/ft/methodearticlemapper/transformation/EomFileProcessor.java
+++ b/src/main/java/com/ft/methodearticlemapper/transformation/EomFileProcessor.java
@@ -1,6 +1,7 @@
 package com.ft.methodearticlemapper.transformation;
 
 import com.ft.bodyprocessing.BodyProcessor;
+import com.ft.content.model.AlternativeStandfirsts;
 import com.ft.uuidutils.DeriveUUID;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSortedSet;
@@ -85,6 +86,7 @@ public class EomFileProcessor {
     private static final String STANDFIRST_XPATH = "/doc/lead/web-stand-first";
     private static final String BYLINE_XPATH = "/doc/story/text/byline";
     private static final String SUBSCRIPTION_LEVEL_XPATH = "/ObjectMetadata/OutputChannels/DIFTcom/DIFTcomSubscriptionLevel";
+    private static final String PROMOTIONAL_STANDFIRST_XPATH = "/doc/lead/web-subhead";
 
     private static final String START_BODY = "<body";
     private static final String END_BODY = "</body>";
@@ -198,6 +200,10 @@ public class EomFileProcessor {
         final String contentPackage = getContentPackage(type, xpath, value, uuid);
         final Distribution canBeDistributed = getCanBeDistributed(eomFile.getContentSource(), type);
 
+        final AlternativeStandfirsts alternativeStandfirsts = AlternativeStandfirsts.builder()
+                .withPromotionalStandfirst(Strings.nullToEmpty(xpath.evaluate(PROMOTIONAL_STANDFIRST_XPATH, value)).trim())
+                .build();
+
         return Content.builder()
                 .withUuid(uuid)
                 .withTitle(headline)
@@ -222,6 +228,7 @@ public class EomFileProcessor {
                 .withDescription(description)
                 .withContentPackage(contentPackage)
                 .withCanBeDistributed(canBeDistributed)
+                .withAlternativeStandfirsts(alternativeStandfirsts)
                 .build();
     }
 

--- a/src/test/java/com/ft/methodearticlemapper/transformation/EomFileProcessorTest.java
+++ b/src/test/java/com/ft/methodearticlemapper/transformation/EomFileProcessorTest.java
@@ -33,7 +33,6 @@ import com.google.common.collect.Maps;
 import com.samskivert.mustache.Mustache;
 import com.samskivert.mustache.Template;
 
-import joptsimple.internal.Strings;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -1035,7 +1034,7 @@ public class EomFileProcessorTest {
                 .build();
 
         Content content = eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, LAST_MODIFIED);
-        assertThat(content.getAlternativeStandfirsts().getPromotionalStandfirst(), is(equalToIgnoringWhiteSpace(Strings.EMPTY)));
+        assertThat(content.getAlternativeStandfirsts().getPromotionalStandfirst(), is(equalToIgnoringWhiteSpace("")));
     }
 
     private void testContentPackage(final String description,
@@ -1281,7 +1280,7 @@ public class EomFileProcessorTest {
                 .withCanBeDistributed(contentSource == ContentSource.FT
                         ? Distribution.YES
                         : contentSource == ContentSource.Reuters ? Distribution.NO : Distribution.VERIFY)
-                .withAlternativeStandfirsts(new AlternativeStandfirsts(Strings.EMPTY))
+                .withAlternativeStandfirsts(new AlternativeStandfirsts(""))
                 .build();
     }
 }

--- a/src/test/java/com/ft/methodearticlemapper/transformation/EomFileProcessorTest.java
+++ b/src/test/java/com/ft/methodearticlemapper/transformation/EomFileProcessorTest.java
@@ -4,6 +4,7 @@ import com.ft.bodyprocessing.BodyProcessor;
 import com.ft.bodyprocessing.html.Html5SelfClosingTagBodyProcessor;
 import com.ft.common.FileUtils;
 import com.ft.content.model.AccessLevel;
+import com.ft.content.model.AlternativeStandfirsts;
 import com.ft.content.model.AlternativeTitles;
 import com.ft.content.model.Brand;
 import com.ft.content.model.Comments;
@@ -32,6 +33,7 @@ import com.google.common.collect.Maps;
 import com.samskivert.mustache.Mustache;
 import com.samskivert.mustache.Template;
 
+import joptsimple.internal.Strings;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -110,6 +112,7 @@ public class EomFileProcessorTest {
     private static final String TEMPLATE_PLACEHOLDER_CONTENT_PACKAGE_DESC = "contentPackageDesc";
     private static final String TEMPLATE_PLACEHOLDER_CONTENT_PACKAGE_LIST_HREF = "contentPackageListHref";
     private static final String TEMPLATE_CONTENT_PACKAGE_TITLE = "contentPackageTitle";
+    private static final String TEMPLATE_WEB_SUBHEAD = "webSubhead";
 
     private static final String IMAGE_SET_UUID = "U116035516646705FC";
 
@@ -1009,6 +1012,32 @@ public class EomFileProcessorTest {
         assertThat(content.getBody(), equalToIgnoringWhiteSpace(expectedBody));
     }
 
+    @Test
+    public void thatAlternativeStandfirtstIsPresent() {
+        final String expectedPromotionalStandfirst = "Test promotional Standfirst";
+
+        Map<String, Object> templateValues = new HashMap<>();
+        templateValues.put(TEMPLATE_WEB_SUBHEAD, expectedPromotionalStandfirst);
+
+        final EomFile eomFile = (new EomFile.Builder())
+                .withValuesFrom(createStandardEomFile(uuid))
+                .withValue(buildEomFileValue(templateValues))
+                .build();
+
+        Content content = eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, LAST_MODIFIED);
+        assertThat(content.getAlternativeStandfirsts().getPromotionalStandfirst(), is(equalToIgnoringWhiteSpace(expectedPromotionalStandfirst)));
+    }
+
+    @Test
+    public void thatAlternativeStandfirtstIsNotPresent() {
+        final EomFile eomFile = (new EomFile.Builder())
+                .withValuesFrom(createStandardEomFile(uuid))
+                .build();
+
+        Content content = eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, LAST_MODIFIED);
+        assertThat(content.getAlternativeStandfirsts().getPromotionalStandfirst(), is(equalToIgnoringWhiteSpace(Strings.EMPTY)));
+    }
+
     private void testContentPackage(final String description,
                                     final String listHref,
                                     final String expectedDescription,
@@ -1252,6 +1281,7 @@ public class EomFileProcessorTest {
                 .withCanBeDistributed(contentSource == ContentSource.FT
                         ? Distribution.YES
                         : contentSource == ContentSource.Reuters ? Distribution.NO : Distribution.VERIFY)
+                .withAlternativeStandfirsts(new AlternativeStandfirsts(Strings.EMPTY))
                 .build();
     }
 }

--- a/src/test/java/com/ft/methodearticlemapper/transformation/EomFileProcessorTest.java
+++ b/src/test/java/com/ft/methodearticlemapper/transformation/EomFileProcessorTest.java
@@ -1034,7 +1034,7 @@ public class EomFileProcessorTest {
                 .build();
 
         Content content = eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, LAST_MODIFIED);
-        assertThat(content.getAlternativeStandfirsts().getPromotionalStandfirst(), is(equalToIgnoringWhiteSpace("")));
+        assertThat(content.getAlternativeStandfirsts().getPromotionalStandfirst(), is(nullValue()));
     }
 
     private void testContentPackage(final String description,
@@ -1280,7 +1280,7 @@ public class EomFileProcessorTest {
                 .withCanBeDistributed(contentSource == ContentSource.FT
                         ? Distribution.YES
                         : contentSource == ContentSource.Reuters ? Distribution.NO : Distribution.VERIFY)
-                .withAlternativeStandfirsts(new AlternativeStandfirsts(""))
+                .withAlternativeStandfirsts(new AlternativeStandfirsts(null))
                 .build();
     }
 }

--- a/src/test/resources/article/article_value.xml.mustache
+++ b/src/test/resources/article/article_value.xml.mustache
@@ -2,16 +2,16 @@
 <!DOCTYPE doc SYSTEM "/SysConfig/Rules/ftpsi.dtd">
 <doc>
     <lead>
-{{#mainImageUuid}}
-        <lead-images id="U2701877253086gfF">
-            <web-master width="2048" height="1152" id="U2701877253086TGC"
-                        fileref="/FT/Graphics/Online/Master_2048x1152/dummy.jpg?uuid={{mainImageUuid}}"/>
-            <web-skybox-picture/>
-            <web-alt-picture/>
-            <web-popup-preview width="167" height="96"/>
-            <web-popup/>
-        </lead-images>
-{{/mainImageUuid}}
+        {{#mainImageUuid}}
+            <lead-images id="U2701877253086gfF">
+                <web-master width="2048" height="1152" id="U2701877253086TGC"
+                            fileref="/FT/Graphics/Online/Master_2048x1152/dummy.jpg?uuid={{mainImageUuid}}"/>
+                <web-skybox-picture/>
+                <web-alt-picture/>
+                <web-popup-preview width="167" height="96"/>
+                <web-popup/>
+            </lead-images>
+        {{/mainImageUuid}}
         <lead-headline>
             <headline>
                 <ln>
@@ -19,43 +19,58 @@
                 </ln>
             </headline>
         </lead-headline>
-{{#promoTitle}}
-        <web-index-headline><ln>{{promoTitle}}</ln>
-        </web-index-headline>
-{{/promoTitle}}
-{{#contentPackageTitle}}
-        <package-navigation-headline><ln>{{contentPackageTitle}}</ln>
-        </package-navigation-headline>
-{{/contentPackageTitle}}
-{{#standfirst}}
-        <web-stand-first><p>{{standfirst}}</p>
-        </web-stand-first>
-{{/standfirst}}
-{{#storyPackageUuid}}
-        <editor-choice id="U2701877253086gfF"><a href="/FT/Content/World%20News/dummy.dwc?uuid={{storyPackageUuid}}">/FT/Content/World%20News/dummy.dwc</a>
-        </editor-choice>
-{{/storyPackageUuid}}
-{{#contentPackage}}
-        <lead-components>
-            <content-package>
-              <content-package-description>{{contentPackageDesc}}</content-package-description>
-              <content-package-link>{{contentPackageListHref}}</content-package-link>
-            </content-package>
-        </lead-components>
-{{/contentPackage}}
+        {{#promoTitle}}
+            <web-index-headline>
+                <ln>{{promoTitle}}</ln>
+            </web-index-headline>
+        {{/promoTitle}}
+        {{#contentPackageTitle}}
+            <package-navigation-headline>
+                <ln>{{contentPackageTitle}}</ln>
+            </package-navigation-headline>
+        {{/contentPackageTitle}}
+        {{#standfirst}}
+            <web-stand-first><p>{{standfirst}}</p>
+            </web-stand-first>
+        {{/standfirst}}
+        {{#storyPackageUuid}}
+            <editor-choice id="U2701877253086gfF"><a
+                    href="/FT/Content/World%20News/dummy.dwc?uuid={{storyPackageUuid}}">/FT/Content/World%20News/dummy.dwc</a>
+            </editor-choice>
+        {{/storyPackageUuid}}
+        {{#contentPackage}}
+            <lead-components>
+                <content-package>
+                    <content-package-description>{{contentPackageDesc}}</content-package-description>
+                    <content-package-link>{{contentPackageListHref}}</content-package-link>
+                </content-package>
+            </lead-components>
+        {{/contentPackage}}
+        {{#webSubhead}}
+            <web-subhead>
+                <p>{{webSubhead}}</p>
+            </web-subhead>
+        {{/webSubhead}}
     </lead>
     <story>
         <text>
-{{#byline}}<byline>{{byline}}</byline>{{/byline}}
+            {{#byline}}
+                <byline>{{byline}}</byline>{{/byline}}
             <body>
-                <p>random text for now</p>
-                {{#imageSetID}}
+            <p>random text for now</p>
+            {{#imageSetID}}
                 <image-set id="{{imageSetID}}">
-                    <image-small id="U11603551664670Dp" fileref="/FT/Content/Companies/Stories/Live/GB/image%20SET/rj/New07.jpg?uuid=069ece4e-2a5d-11e7-9b32-1fc36bdf8f7d" xtransform=" scale(0.0729167 0.0729167)" tmx="2048 1152 71 84"/>
-                    <image-medium id="U11603551664670MgH" fileref="/FT/Content/Companies/Stories/Live/GB/image%20SET/rj/New06.jpg?uuid=077aa180-2a5d-11e7-9b32-1fc36bdf8f7d" xtransform=" scale(0.0842014 0.0842014)" tmx="2048 1152 150 97"/>
-                    <image-large id="U11603551664670OGB" fileref="/FT/Content/Companies/Stories/Live/GB/image%20SET/rj/New05.jpg?uuid=0848103e-2a5d-11e7-9b32-1fc36bdf8f7d" xtransform=" scale(0.0976563 0.0976563)" tmx="2048 1152 200 87"/>
+                    <image-small id="U11603551664670Dp"
+                                 fileref="/FT/Content/Companies/Stories/Live/GB/image%20SET/rj/New07.jpg?uuid=069ece4e-2a5d-11e7-9b32-1fc36bdf8f7d"
+                                 xtransform=" scale(0.0729167 0.0729167)" tmx="2048 1152 71 84"/>
+                    <image-medium id="U11603551664670MgH"
+                                  fileref="/FT/Content/Companies/Stories/Live/GB/image%20SET/rj/New06.jpg?uuid=077aa180-2a5d-11e7-9b32-1fc36bdf8f7d"
+                                  xtransform=" scale(0.0842014 0.0842014)" tmx="2048 1152 150 97"/>
+                    <image-large id="U11603551664670OGB"
+                                 fileref="/FT/Content/Companies/Stories/Live/GB/image%20SET/rj/New05.jpg?uuid=0848103e-2a5d-11e7-9b32-1fc36bdf8f7d"
+                                 xtransform=" scale(0.0976563 0.0976563)" tmx="2048 1152 200 87"/>
                 </image-set>
-                {{/imageSetID}}
+            {{/imageSetID}}
             </body>
         </text>
     </story>


### PR DESCRIPTION
alternativeStanfirsts is a new field that has one field called promotionalStandfirsts which gets it's value from the web-subhead tag.

NB: Don't mind the version of the content-model library. I'll fix that after this https://github.com/Financial-Times/content-model/pull/11 is merged.