### PR TITLE
Find the right tag.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY . /methode-article-mapper
 RUN apk --update add git \
  && cd methode-article-mapper \
  && HASH=$(git log -1 --pretty=format:%H) \
- && TAG=$(git tag -l --contains $HASH) \
+ && TAG=$(git tag -l --points-at $HASH) \
  && VERSION=${TAG:-untagged} \
  && mvn versions:set -DnewVersion=$VERSION \
  && mvn install -Dbuild.git.revision=$HASH -Djava.net.preferIPv4Stack=true \

--- a/README.markdown
+++ b/README.markdown
@@ -29,6 +29,7 @@ This `preview` setting will not trigger an exception in case of empty article bo
 A GET request to http://localhost:11071/healthcheck or http://localhost:11070/__health
 
 ## Example of transformation output 
+
 You can find an example of a transformed article below. 
 
 ```


### PR DESCRIPTION
`--contains` may return more than one value, whereas `--points-at` will
return at most one.