### PR TITLE
Increase memory limit to 1Gi for K8S

### DIFF
--- a/helm/methode-article-mapper/values.yaml
+++ b/helm/methode-article-mapper/values.yaml
@@ -10,7 +10,7 @@ image:
   pullPolicy: IfNotPresent
 resources:
   limits:
-    memory: 512Mi
+    memory: 1Gi
 
 
 


### PR DESCRIPTION
- in the K8S prod clusters we have been experiencing a lot of OOM issues with MAM, so we ran the service with 1Gi limit for a few days and the OOM issues didn't appear again