### PR TITLE
PAC suggest mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY . /methode-article-mapper
 RUN apk --update add git \
  && cd methode-article-mapper \
  && HASH=$(git log -1 --pretty=format:%H) \
- && TAG=$(git tag -l --points-at $HASH) \
+ && TAG=$(git tag -l --points-at $HASH | head -n1) \
  && VERSION=${TAG:-untagged} \
  && mvn versions:set -DnewVersion=$VERSION \
  && mvn install -Dbuild.git.revision=$HASH -Djava.net.preferIPv4Stack=true \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,11 @@ EXPOSE 8080 8081
 CMD exec java $JAVA_OPTS \
      -Ddw.server.applicationConnectors[0].port=8080 \
      -Ddw.server.adminConnectors[0].port=8081 \
+     -Ddw.documentStoreApiEnabled=$DOCUMENT_STORE_API_ENABLED \
      -Ddw.documentStoreApi.endpointConfiguration.primaryNodes=$DOCUMENT_STORE_API_URL \
+     -Ddw.concordanceApiEnabled=$CONCORDANCE_API_ENABLED \
      -Ddw.concordanceApi.endpointConfiguration.primaryNodes=$CONCORDANCE_API_URL \
+     -Ddw.messagingEndpointEnabled=$KAFKA_ENABLED \
      -Ddw.consumer.messageConsumer.queueProxyHost=http://$KAFKA_PROXY_URL \
      -Ddw.producer.messageProducer.proxyHostAndPort=$KAFKA_PROXY_URL \
      -Ddw.apiHost=$API_HOST \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,4 @@
 @Library('k8s-pipeline-lib') _
 
 uppEntryPointForJenkinsfile()
+pacEntryPointForJenkinsfile()

--- a/helm/methode-article-mapper/app-configs/methode-article-mapper_delivery.yaml
+++ b/helm/methode-article-mapper/app-configs/methode-article-mapper_delivery.yaml
@@ -3,6 +3,18 @@ replicaCount: 2
 service:
   name: methode-article-mapper
 env:
-  KAFKA_ENABLED: true
-  DOCUMENT_STORE_API_ENABLED: true
-  CONCORDANCE_API_ENABLED: true
+  - name: KAFKA_ENABLED
+    value: true
+  - name: KAFKA_PROXY_URL
+    valueFrom:
+      configMapKeyRef:
+        name: global-config
+        key: kafka.proxy.url
+  - name: DOCUMENT_STORE_API_ENABLED
+    value: true
+  - name: DOCUMENT_STORE_API_URL
+    value: "document-store-api:8080"
+  - name: CONCORDANCE_API_ENABLED
+    value: true
+  - name: CONCORDANCE_API_URL
+    value: "public-concordances-api:8080"

--- a/helm/methode-article-mapper/app-configs/methode-article-mapper_delivery.yaml
+++ b/helm/methode-article-mapper/app-configs/methode-article-mapper_delivery.yaml
@@ -12,9 +12,5 @@ env:
         key: kafka.proxy.url
   - name: DOCUMENT_STORE_API_ENABLED
     value: true
-  - name: DOCUMENT_STORE_API_URL
-    value: "document-store-api:8080"
   - name: CONCORDANCE_API_ENABLED
     value: true
-  - name: CONCORDANCE_API_URL
-    value: "public-concordances-api:8080"

--- a/helm/methode-article-mapper/app-configs/methode-article-mapper_delivery.yaml
+++ b/helm/methode-article-mapper/app-configs/methode-article-mapper_delivery.yaml
@@ -3,14 +3,11 @@ replicaCount: 2
 service:
   name: methode-article-mapper
 env:
-  - name: KAFKA_ENABLED
-    value: true
-  - name: KAFKA_PROXY_URL
+  KAFKA_ENABLED: true
+  KAFKA_PROXY_URL:
     valueFrom:
       configMapKeyRef:
         name: global-config
         key: kafka.proxy.url
-  - name: DOCUMENT_STORE_API_ENABLED
-    value: true
-  - name: CONCORDANCE_API_ENABLED
-    value: true
+  DOCUMENT_STORE_API_ENABLED: true
+  CONCORDANCE_API_ENABLED: true

--- a/helm/methode-article-mapper/app-configs/methode-article-mapper_delivery.yaml
+++ b/helm/methode-article-mapper/app-configs/methode-article-mapper_delivery.yaml
@@ -4,13 +4,13 @@ service:
   name: methode-article-mapper
 env:
   - name: KAFKA_ENABLED
-    value: "true"
+    value: true
   - name: KAFKA_PROXY_URL
     valueFrom:
       configMapKeyRef:
         name: global-config
         key: kafka.proxy.url
   - name: DOCUMENT_STORE_API_ENABLED
-    value: "true"
+    value: true
   - name: CONCORDANCE_API_ENABLED
-    value: "true"
+    value: true

--- a/helm/methode-article-mapper/app-configs/methode-article-mapper_delivery.yaml
+++ b/helm/methode-article-mapper/app-configs/methode-article-mapper_delivery.yaml
@@ -4,10 +4,5 @@ service:
   name: methode-article-mapper
 env:
   KAFKA_ENABLED: true
-  KAFKA_PROXY_URL:
-    valueFrom:
-      configMapKeyRef:
-        name: global-config
-        key: kafka.proxy.url
   DOCUMENT_STORE_API_ENABLED: true
   CONCORDANCE_API_ENABLED: true

--- a/helm/methode-article-mapper/app-configs/methode-article-mapper_delivery.yaml
+++ b/helm/methode-article-mapper/app-configs/methode-article-mapper_delivery.yaml
@@ -4,13 +4,13 @@ service:
   name: methode-article-mapper
 env:
   - name: KAFKA_ENABLED
-    value: true
+    value: "true"
   - name: KAFKA_PROXY_URL
     valueFrom:
       configMapKeyRef:
         name: global-config
         key: kafka.proxy.url
   - name: DOCUMENT_STORE_API_ENABLED
-    value: true
+    value: "true"
   - name: CONCORDANCE_API_ENABLED
-    value: true
+    value: "true"

--- a/helm/methode-article-mapper/app-configs/methode-article-mapper_pac.yaml
+++ b/helm/methode-article-mapper/app-configs/methode-article-mapper_pac.yaml
@@ -3,6 +3,6 @@ replicaCount: 2
 service:
   name: methode-article-mapper
 env:
-  KAFKA_ENABLED: true
-  DOCUMENT_STORE_API_ENABLED: true
-  CONCORDANCE_API_ENABLED: true
+  KAFKA_ENABLED: false
+  DOCUMENT_STORE_API_ENABLED: false
+  CONCORDANCE_API_ENABLED: false

--- a/helm/methode-article-mapper/app-configs/methode-article-mapper_pac.yaml
+++ b/helm/methode-article-mapper/app-configs/methode-article-mapper_pac.yaml
@@ -4,8 +4,8 @@ service:
   name: methode-article-mapper
 env:
   - name: KAFKA_ENABLED
-    value: "false"
+    value: false
   - name: DOCUMENT_STORE_API_ENABLED
-    value: "false"
+    value: false
   - name: CONCORDANCE_API_ENABLED
-    value: "false"
+    value: false

--- a/helm/methode-article-mapper/app-configs/methode-article-mapper_pac.yaml
+++ b/helm/methode-article-mapper/app-configs/methode-article-mapper_pac.yaml
@@ -4,8 +4,8 @@ service:
   name: methode-article-mapper
 env:
   - name: KAFKA_ENABLED
-    value: false
+    value: "false"
   - name: DOCUMENT_STORE_API_ENABLED
-    value: false
+    value: "false"
   - name: CONCORDANCE_API_ENABLED
-    value: false
+    value: "false"

--- a/helm/methode-article-mapper/app-configs/methode-article-mapper_pac.yaml
+++ b/helm/methode-article-mapper/app-configs/methode-article-mapper_pac.yaml
@@ -3,6 +3,9 @@ replicaCount: 2
 service:
   name: methode-article-mapper
 env:
-  KAFKA_ENABLED: false
-  DOCUMENT_STORE_API_ENABLED: false
-  CONCORDANCE_API_ENABLED: false
+  - name: KAFKA_ENABLED
+    value: false
+  - name: DOCUMENT_STORE_API_ENABLED
+    value: false
+  - name: CONCORDANCE_API_ENABLED
+    value: false

--- a/helm/methode-article-mapper/app-configs/methode-article-mapper_pac.yaml
+++ b/helm/methode-article-mapper/app-configs/methode-article-mapper_pac.yaml
@@ -3,9 +3,6 @@ replicaCount: 2
 service:
   name: methode-article-mapper
 env:
-  - name: KAFKA_ENABLED
-    value: false
-  - name: DOCUMENT_STORE_API_ENABLED
-    value: false
-  - name: CONCORDANCE_API_ENABLED
-    value: false
+  KAFKA_ENABLED: false
+  DOCUMENT_STORE_API_ENABLED: false
+  CONCORDANCE_API_ENABLED: false

--- a/helm/methode-article-mapper/templates/admin-ingress.yaml
+++ b/helm/methode-article-mapper/templates/admin-ingress.yaml
@@ -1,0 +1,22 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{.Values.service.name}}-admin-ingress
+  annotations:
+    # type of authentication
+    ingress.kubernetes.io/auth-type: basic
+    # name of the secret that contains the user/password definitions
+    ingress.kubernetes.io/auth-secret: basic-auth
+    # message to display with an appropriate context why the authentication is required
+    ingress.kubernetes.io/auth-realm: "Authentication Required"
+    ingress.kubernetes.io/rewrite-target: /
+
+spec:
+  rules:
+    - host: "*.ft.com"
+      http:
+        paths:
+        - path: /__{{.Values.service.name}}/
+          backend:
+            serviceName: {{.Values.service.name}}
+            servicePort: 8080

--- a/helm/methode-article-mapper/templates/deployment.yaml
+++ b/helm/methode-article-mapper/templates/deployment.yaml
@@ -36,15 +36,15 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         - name: KAFKA_ENABLED
-          value: false
+          value: "false"
         - name: KAFKA_PROXY_URL
           value: "kafka-rest-proxy:8080"
         - name: DOCUMENT_STORE_API_ENABLED
-          value: false
+          value: "false"
         - name: DOCUMENT_STORE_API_URL
           value: "document-store-api:8080"
         - name: CONCORDANCE_API_ENABLED
-          value: false
+          value: "false"
         - name: CONCORDANCE_API_URL
           value: "public-concordances-api:8080"
         - name: API_HOST

--- a/helm/methode-article-mapper/templates/deployment.yaml
+++ b/helm/methode-article-mapper/templates/deployment.yaml
@@ -35,8 +35,16 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Chart.Version }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
+        - name: KAFKA_ENABLED
+          value: false
+        - name: KAFKA_PROXY_URL
+          value: "kafka-rest-proxy:8080"
+        - name: DOCUMENT_STORE_API_ENABLED
+          value: false
         - name: DOCUMENT_STORE_API_URL
           value: "document-store-api:8080"
+        - name: CONCORDANCE_API_ENABLED
+          value: false
         - name: CONCORDANCE_API_URL
           value: "public-concordances-api:8080"
         - name: API_HOST

--- a/helm/methode-article-mapper/templates/deployment.yaml
+++ b/helm/methode-article-mapper/templates/deployment.yaml
@@ -38,7 +38,14 @@ spec:
         - name: KAFKA_ENABLED
           value: "{{ .Values.env.KAFKA_ENABLED}}"
         - name: KAFKA_PROXY_URL
-          value: {{ .Values.env.KAFKA_PROXY_URL | default "kafka-rest-proxy:8080" | quote }}
+          {{- if .Values.env.KAFKA_ENABLED }}
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: kafka.proxy.url
+          {{- else }}
+          value: "kafka-rest-proxy:8080"
+          {{- end}}
         - name: DOCUMENT_STORE_API_ENABLED
           value: "{{ .Values.env.DOCUMENT_STORE_API_ENABLED }}"
         - name: DOCUMENT_STORE_API_URL

--- a/helm/methode-article-mapper/templates/deployment.yaml
+++ b/helm/methode-article-mapper/templates/deployment.yaml
@@ -36,15 +36,15 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         - name: KAFKA_ENABLED
-          value: "false"
+          value: "{{ .Values.env.KAFKA_ENABLED}}"
         - name: KAFKA_PROXY_URL
-          value: "kafka-rest-proxy:8080"
+          value: {{ .Values.env.KAFKA_PROXY_URL | default "kafka-rest-proxy:8080" | quote }}
         - name: DOCUMENT_STORE_API_ENABLED
-          value: "false"
+          value: "{{ .Values.env.DOCUMENT_STORE_API_ENABLED }}"
         - name: DOCUMENT_STORE_API_URL
           value: "document-store-api:8080"
         - name: CONCORDANCE_API_ENABLED
-          value: "false"
+          value: "{{ .Values.env.CONCORDANCE_API_ENABLED }}"
         - name: CONCORDANCE_API_URL
           value: "public-concordances-api:8080"
         - name: API_HOST

--- a/helm/methode-article-mapper/templates/deployment.yaml
+++ b/helm/methode-article-mapper/templates/deployment.yaml
@@ -35,15 +35,6 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Chart.Version }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
-        - name: DOCUMENT_STORE_API_URL
-          value: "document-store-api:8080"
-        - name: CONCORDANCE_API_URL
-          value: "public-concordances-api:8080"
-        - name: KAFKA_PROXY_URL
-          valueFrom:
-            configMapKeyRef:
-              name: global-config
-              key: kafka.proxy.url
         - name: API_HOST
           valueFrom:
             configMapKeyRef:

--- a/helm/methode-article-mapper/templates/deployment.yaml
+++ b/helm/methode-article-mapper/templates/deployment.yaml
@@ -35,6 +35,10 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Chart.Version }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
+        - name: DOCUMENT_STORE_API_URL
+          value: "document-store-api:8080"
+        - name: CONCORDANCE_API_URL
+          value: "public-concordances-api:8080"
         - name: API_HOST
           valueFrom:
             configMapKeyRef:

--- a/helm/methode-article-mapper/values.yaml
+++ b/helm/methode-article-mapper/values.yaml
@@ -13,7 +13,7 @@ resources:
     memory: 1536Mi
   requests:
     memory: 1Gi
-
-
-
-
+env:
+  KAFKA_ENABLED: false
+  DOCUMENT_STORE_API_ENABLED: false
+  CONCORDANCE_API_ENABLED: false

--- a/methode-article-mapper.yaml
+++ b/methode-article-mapper.yaml
@@ -75,6 +75,7 @@ logging:
 
     - type: console
       
+documentStoreApiEnabled: true
 documentStoreApi:
     endpointConfiguration:
         shortName: "documentStoreApi"
@@ -87,6 +88,7 @@ documentStoreApi:
         numberOfConnectionAttempts: 3
         timeoutMultiplier: 1000
 
+concordanceApiEnabled: true
 concordanceApi:
     endpointConfiguration:
         shortName: "concordance"
@@ -99,6 +101,7 @@ concordanceApi:
         numberOfConnectionAttempts: 3
         timeoutMultiplier: 1000  
 
+messagingEndpointEnabled: true
 consumer:
   jerseyClient:
     connectionTimeout: 2 seconds

--- a/src/main/java/com/ft/methodearticlemapper/MethodeArticleMapperApplication.java
+++ b/src/main/java/com/ft/methodearticlemapper/MethodeArticleMapperApplication.java
@@ -8,7 +8,6 @@ import com.ft.api.util.transactionid.TransactionIdFilter;
 import com.ft.bodyprocessing.html.Html5SelfClosingTagBodyProcessor;
 import com.ft.bodyprocessing.richcontent.VideoMatcher;
 import com.ft.content.model.Brand;
-import com.ft.jerseyhttpwrapper.ResilientClient;
 import com.ft.jerseyhttpwrapper.ResilientClientBuilder;
 import com.ft.jerseyhttpwrapper.config.EndpointConfiguration;
 import com.ft.jerseyhttpwrapper.continuation.ExponentialBackoffContinuationPolicy;
@@ -81,7 +80,7 @@ public class MethodeArticleMapperApplication extends Application<MethodeArticleM
         environment.jersey().register(buildInfoResource);
 
         DocumentStoreApiConfiguration documentStoreApiConfiguration = configuration.getDocumentStoreApiConfiguration();
-        ResilientClient documentStoreApiClient = (ResilientClient) configureResilientClient(environment, documentStoreApiConfiguration.getEndpointConfiguration(), documentStoreApiConfiguration.getConnectionConfig());
+        Client documentStoreApiClient = configureResilientClient(environment, documentStoreApiConfiguration.getEndpointConfiguration(), documentStoreApiConfiguration.getConnectionConfig());
 
         EndpointConfiguration documentStoreApiEndpointConfiguration = documentStoreApiConfiguration.getEndpointConfiguration();
         UriBuilder documentStoreApiBuilder = UriBuilder.fromPath(documentStoreApiEndpointConfiguration.getPath()).scheme("http").host(documentStoreApiEndpointConfiguration.getHost()).port(documentStoreApiEndpointConfiguration.getPort());
@@ -145,7 +144,7 @@ public class MethodeArticleMapperApplication extends Application<MethodeArticleM
     }
 
     private EomFileProcessor configureEomFileProcessorForContentStore(
-            final ResilientClient documentStoreApiClient,
+            final Client documentStoreApiClient,
             final URI documentStoreUri,
             final MethodeArticleMapperConfiguration configuration,
             final Client concordanceApiClient,
@@ -173,7 +172,7 @@ public class MethodeArticleMapperApplication extends Application<MethodeArticleM
 
     private List<AdvancedHealthCheck> buildClientHealthChecks(
             Client concordanceApiClient, EndpointConfiguration concordanceApiConfiguration,
-            ResilientClient documentStoreApiClient, EndpointConfiguration documentStoreApiEndpointConfiguration) {
+            Client documentStoreApiClient, EndpointConfiguration documentStoreApiEndpointConfiguration) {
 
         List<AdvancedHealthCheck> healthchecks = new ArrayList<>();
         healthchecks.add(new RemoteServiceHealthCheck(

--- a/src/main/java/com/ft/methodearticlemapper/MethodeArticleMapperApplication.java
+++ b/src/main/java/com/ft/methodearticlemapper/MethodeArticleMapperApplication.java
@@ -36,6 +36,7 @@ import com.ft.methodearticlemapper.transformation.BodyProcessingFieldTransformer
 import com.ft.methodearticlemapper.transformation.BylineProcessingFieldTransformerFactory;
 import com.ft.methodearticlemapper.transformation.EomFileProcessor;
 import com.ft.methodearticlemapper.transformation.InteractiveGraphicsMatcher;
+import com.ft.methodearticlemapper.transformation.TransformationMode;
 import com.ft.platform.dropwizard.AdvancedHealthCheck;
 import com.ft.platform.dropwizard.AdvancedHealthCheckBundle;
 import com.ft.platform.dropwizard.DefaultGoodToGoChecker;
@@ -179,7 +180,16 @@ public class MethodeArticleMapperApplication extends Application<MethodeArticleM
             final MethodeArticleMapperConfiguration configuration,
             final Client concordanceApiClient,
             final URI concordanceUri) {
+        
+        EnumSet<TransformationMode> supportedModes;
+        if ((documentStoreApiClient != null) && (concordanceApiClient != null)) {
+            supportedModes = EnumSet.allOf(TransformationMode.class);
+        } else {
+            supportedModes = EnumSet.of(TransformationMode.SUGGEST);
+        }
+        
         return new EomFileProcessor(
+                supportedModes,
                 new BodyProcessingFieldTransformerFactory(documentStoreApiClient,
                         documentStoreUri,
                         new VideoMatcher(configuration.getVideoSiteConfig()),

--- a/src/main/java/com/ft/methodearticlemapper/MethodeArticleMapperApplication.java
+++ b/src/main/java/com/ft/methodearticlemapper/MethodeArticleMapperApplication.java
@@ -25,6 +25,7 @@ import com.ft.methodearticlemapper.configuration.ProducerConfiguration;
 import com.ft.methodearticlemapper.exception.ConfigurationException;
 import com.ft.methodearticlemapper.health.CanConnectToMessageQueueProducerProxyHealthcheck;
 import com.ft.methodearticlemapper.health.RemoteServiceHealthCheck;
+import com.ft.methodearticlemapper.health.StandaloneHealthCheck;
 import com.ft.methodearticlemapper.messaging.MessageBuilder;
 import com.ft.methodearticlemapper.messaging.MessageProducingArticleMapper;
 import com.ft.methodearticlemapper.messaging.NativeCmsPublicationEventsListener;
@@ -57,7 +58,8 @@ import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 
 public class MethodeArticleMapperApplication extends Application<MethodeArticleMapperConfiguration> {
-
+    private static final String DEWEY_URL = "https://dewey.ft.com/up-mam.html";
+    
     public static void main(final String[] args) throws Exception {
         new MethodeArticleMapperApplication().run(args);
     }
@@ -79,19 +81,33 @@ public class MethodeArticleMapperApplication extends Application<MethodeArticleM
         BuildInfoResource buildInfoResource = new BuildInfoResource();
         environment.jersey().register(buildInfoResource);
 
-        DocumentStoreApiConfiguration documentStoreApiConfiguration = configuration.getDocumentStoreApiConfiguration();
-        Client documentStoreApiClient = configureResilientClient(environment, documentStoreApiConfiguration.getEndpointConfiguration(), documentStoreApiConfiguration.getConnectionConfig());
+        List<AdvancedHealthCheck> healthchecks = new ArrayList<>();
+        
+        Client documentStoreApiClient = null;
+        URI documentStoreUri = null;
+        if (configuration.isDocumentStoreApiEnabled()) {
+            DocumentStoreApiConfiguration documentStoreApiConfiguration = configuration.getDocumentStoreApiConfiguration();
+            EndpointConfiguration documentStoreApiEndpointConfiguration = documentStoreApiConfiguration.getEndpointConfiguration();
+            documentStoreApiClient = configureResilientClient(environment, documentStoreApiEndpointConfiguration, documentStoreApiConfiguration.getConnectionConfig());
+            
+            UriBuilder documentStoreApiBuilder = UriBuilder.fromPath(documentStoreApiEndpointConfiguration.getPath()).scheme("http").host(documentStoreApiEndpointConfiguration.getHost()).port(documentStoreApiEndpointConfiguration.getPort());
+            documentStoreUri = documentStoreApiBuilder.build();
 
-        EndpointConfiguration documentStoreApiEndpointConfiguration = documentStoreApiConfiguration.getEndpointConfiguration();
-        UriBuilder documentStoreApiBuilder = UriBuilder.fromPath(documentStoreApiEndpointConfiguration.getPath()).scheme("http").host(documentStoreApiEndpointConfiguration.getHost()).port(documentStoreApiEndpointConfiguration.getPort());
-        URI documentStoreUri = documentStoreApiBuilder.build();
-
-        ConcordanceApiConfiguration concordanceApiConfiguration = configuration.getConcordanceApiConfiguration();
-        Client concordanceApiClient = configureResilientClient(environment, concordanceApiConfiguration.getEndpointConfiguration(), concordanceApiConfiguration.getConnectionConfiguration());
-        EndpointConfiguration concordanceApiEndpointConfiguration = concordanceApiConfiguration.getEndpointConfiguration();
-        UriBuilder concordanceApiBuilder = UriBuilder.fromPath(concordanceApiEndpointConfiguration.getPath()).scheme("http").host(concordanceApiEndpointConfiguration.getHost()).port(concordanceApiEndpointConfiguration.getPort());
-        URI concordanceUri = concordanceApiBuilder.build();
-
+            healthchecks.add(buildDocumentStoreAPIHealthCheck(documentStoreApiClient, documentStoreApiEndpointConfiguration));
+        }
+        
+        Client concordanceApiClient = null;
+        URI concordanceUri = null;
+        if (configuration.isConcordanceApiEnabled()) {
+            ConcordanceApiConfiguration concordanceApiConfiguration = configuration.getConcordanceApiConfiguration();
+            EndpointConfiguration concordanceApiEndpointConfiguration = concordanceApiConfiguration.getEndpointConfiguration();
+            concordanceApiClient = configureResilientClient(environment, concordanceApiEndpointConfiguration, concordanceApiConfiguration.getConnectionConfiguration());
+            UriBuilder concordanceApiBuilder = UriBuilder.fromPath(concordanceApiEndpointConfiguration.getPath()).scheme("http").host(concordanceApiEndpointConfiguration.getHost()).port(concordanceApiEndpointConfiguration.getPort());
+            concordanceUri = concordanceApiBuilder.build();
+            
+            healthchecks.add(buildConcordanceAPIHealthCheck(concordanceApiClient, concordanceApiEndpointConfiguration));
+        }
+        
         EomFileProcessor eomFileProcessor = configureEomFileProcessorForContentStore(
                 documentStoreApiClient,
                 documentStoreUri,
@@ -100,32 +116,46 @@ public class MethodeArticleMapperApplication extends Application<MethodeArticleM
                 concordanceUri
         );
 
-        ConsumerConfiguration consumerConfig = configuration.getConsumerConfiguration();
-        MessageProducingArticleMapper msgProducingListMapper = new MessageProducingArticleMapper(
-                getMessageBuilder(configuration, environment),
-                configureMessageProducer(configuration.getProducerConfiguration(), environment),
-                eomFileProcessor
-        );
-        MessageListener listener = new NativeCmsPublicationEventsListener(
-                environment.getObjectMapper(),
-                msgProducingListMapper,
-                consumerConfig.getSystemCode()
-        );
-        registerListener(environment, listener, consumerConfig, getConsumerClient(environment, consumerConfig));
+        if (configuration.isMessagingEndpointEnabled()) {
+            ProducerConfiguration producerConfig = configuration.getProducerConfiguration();
+            Client producerClient = getMessagingClient(environment, producerConfig.getJerseyClientConfiguration(), "producer-client");
+            QueueProxyProducer.BuildNeeded queueProxyBuilder = QueueProxyProducer.builder()
+                    .withJerseyClient(producerClient)
+                    .withQueueProxyConfiguration(producerConfig.getMessageQueueProducerConfiguration());
 
-        registerHealthChecks(
-                environment,
-                buildClientHealthChecks(
-                        concordanceApiClient, concordanceApiConfiguration.getEndpointConfiguration(),
-                        documentStoreApiClient, documentStoreApiConfiguration.getEndpointConfiguration()
-                )
-        );
+            MessageProducer producer = queueProxyBuilder.build();
+            healthchecks.add(buildProducerHealthCheck(environment, producerConfig, queueProxyBuilder));
+            
+            MessageProducingArticleMapper msgProducingListMapper = new MessageProducingArticleMapper(
+                    getMessageBuilder(configuration, environment),
+                    producer, eomFileProcessor);
+            
+            ConsumerConfiguration consumerConfig = configuration.getConsumerConfiguration();
+            MessageListener listener = new NativeCmsPublicationEventsListener(
+                    environment.getObjectMapper(),
+                    msgProducingListMapper,
+                    consumerConfig.getSystemCode()
+                    );
+            
+            healthchecks.add(
+                    registerListener(environment, listener, consumerConfig,
+                            getMessagingClient(environment, consumerConfig.getJerseyClientConfiguration(), "consumer-client")
+                            )
+                    );
+        }
 
         environment.jersey().register(
                 new PostContentToTransformResource(
                         eomFileProcessor
                 )
         );
+        
+        if (healthchecks.isEmpty()) {
+            // nothing to check, but prevent alarming startup messages
+            healthchecks.add(new StandaloneHealthCheck(DEWEY_URL));
+        }
+        
+        registerHealthChecks(environment, healthchecks);
 
         environment.jersey().register(RuntimeExceptionMapper.class);
         Errors.customise(new MethodeArticleTransformerErrorEntityFactory());
@@ -170,12 +200,8 @@ public class MethodeArticleMapperApplication extends Application<MethodeArticleM
         }
     }
 
-    private List<AdvancedHealthCheck> buildClientHealthChecks(
-            Client concordanceApiClient, EndpointConfiguration concordanceApiConfiguration,
-            Client documentStoreApiClient, EndpointConfiguration documentStoreApiEndpointConfiguration) {
-
-        List<AdvancedHealthCheck> healthchecks = new ArrayList<>();
-        healthchecks.add(new RemoteServiceHealthCheck(
+    private AdvancedHealthCheck buildConcordanceAPIHealthCheck(Client concordanceApiClient, EndpointConfiguration concordanceApiConfiguration) {
+        return new RemoteServiceHealthCheck(
                 "Public Concordance API",
                 concordanceApiClient,
                 concordanceApiConfiguration.getHost(),
@@ -184,9 +210,11 @@ public class MethodeArticleMapperApplication extends Application<MethodeArticleM
                 "public-concordances-api",
                 1,
                 "Articles will not be annotated with company tearsheet information.",
-                "https://dewey.ft.com/up-mam.html")
-        );
-        healthchecks.add(new RemoteServiceHealthCheck(
+                DEWEY_URL);
+    }
+    
+    private AdvancedHealthCheck buildDocumentStoreAPIHealthCheck(Client documentStoreApiClient, EndpointConfiguration documentStoreApiEndpointConfiguration) {
+        return new RemoteServiceHealthCheck(
                 "Document Store API",
                 documentStoreApiClient,
                 documentStoreApiEndpointConfiguration.getHost(),
@@ -195,9 +223,7 @@ public class MethodeArticleMapperApplication extends Application<MethodeArticleM
                 "document-store-api",
                 1,
                 "Clients will be unable to query the content service using alternative identifiers.",
-                "https://dewey.ft.com/up-mam.html")
-        );
-        return healthchecks;
+                DEWEY_URL);
     }
 
     private MessageBuilder getMessageBuilder(MethodeArticleMapperConfiguration configuration, Environment environment) {
@@ -208,41 +234,18 @@ public class MethodeArticleMapperApplication extends Application<MethodeArticleM
         );
     }
 
-    private Client getConsumerClient(Environment environment, ConsumerConfiguration config) {
-        JerseyClientConfiguration jerseyConfig = config.getJerseyClientConfiguration();
+    private Client getMessagingClient(Environment environment, JerseyClientConfiguration jerseyConfig, String name) {
         jerseyConfig.setGzipEnabled(false);
         jerseyConfig.setGzipEnabledForRequests(false);
 
         return ResilientClientBuilder.in(environment)
                 .using(jerseyConfig)
                 .usingDNS()
-                .named("consumer-client")
+                .named(name)
                 .build();
     }
 
-    protected MessageProducer configureMessageProducer(ProducerConfiguration config, Environment environment) {
-        JerseyClientConfiguration jerseyConfig = config.getJerseyClientConfiguration();
-        jerseyConfig.setGzipEnabled(false);
-        jerseyConfig.setGzipEnabledForRequests(false);
-
-        Client producerClient = ResilientClientBuilder.in(environment)
-                .using(jerseyConfig)
-                .usingDNS()
-                .named("producer-client")
-                .build();
-
-        final QueueProxyProducer.BuildNeeded queueProxyBuilder = QueueProxyProducer.builder()
-                .withJerseyClient(producerClient)
-                .withQueueProxyConfiguration(config.getMessageQueueProducerConfiguration());
-
-        final QueueProxyProducer producer = queueProxyBuilder.build();
-
-        registerProducerHealthCheck(environment, config, queueProxyBuilder);
-
-        return producer;
-    }
-
-    protected void registerListener(Environment environment, MessageListener listener, ConsumerConfiguration config, Client consumerClient) {
+    protected AdvancedHealthCheck registerListener(Environment environment, MessageListener listener, ConsumerConfiguration config, Client consumerClient) {
         final MessageQueueConsumerInitializer messageQueueConsumerInitializer =
                 new MessageQueueConsumerInitializer(
                         config.getMessageQueueConsumerConfiguration(),
@@ -251,24 +254,20 @@ public class MethodeArticleMapperApplication extends Application<MethodeArticleM
                 );
         environment.lifecycle().manage(messageQueueConsumerInitializer);
 
-        registerConsumerHealthCheck(environment, config, messageQueueConsumerInitializer);
+        return buildConsumerHealthCheck(environment, config, messageQueueConsumerInitializer);
     }
 
-    private void registerProducerHealthCheck(Environment environment, ProducerConfiguration config, QueueProxyProducer.BuildNeeded queueProxyBuilder) {
-        environment.healthChecks().register("KafkaProxyProducer",
-                new CanConnectToMessageQueueProducerProxyHealthcheck(
-                        queueProxyBuilder.buildHealthcheck(),
-                        config.getHealthcheckConfiguration(),
-                        environment.metrics()
-                )
+    private AdvancedHealthCheck buildProducerHealthCheck(Environment environment, ProducerConfiguration config, QueueProxyProducer.BuildNeeded queueProxyBuilder) {
+        return new CanConnectToMessageQueueProducerProxyHealthcheck(
+                queueProxyBuilder.buildHealthcheck(),
+                config.getHealthcheckConfiguration(),
+                environment.metrics()
         );
     }
-
-    private void registerConsumerHealthCheck(Environment environment, ConsumerConfiguration config, MessageQueueConsumerInitializer messageQueueConsumerInitializer) {
-        environment.healthChecks().register("KafkaProxyConsumer",
-                messageQueueConsumerInitializer.buildPassiveConsumerHealthcheck(
-                        config.getHealthcheckConfiguration(), environment.metrics()
-                )
+    
+    private AdvancedHealthCheck buildConsumerHealthCheck(Environment environment, ConsumerConfiguration config, MessageQueueConsumerInitializer messageQueueConsumerInitializer) {
+        return messageQueueConsumerInitializer.buildPassiveConsumerHealthcheck(
+                config.getHealthcheckConfiguration(), environment.metrics()
         );
     }
 

--- a/src/main/java/com/ft/methodearticlemapper/configuration/MethodeArticleMapperConfiguration.java
+++ b/src/main/java/com/ft/methodearticlemapper/configuration/MethodeArticleMapperConfiguration.java
@@ -9,20 +9,25 @@ import io.dropwizard.Configuration;
 import java.util.List;
 
 public class MethodeArticleMapperConfiguration extends Configuration {
-	
-	private final DocumentStoreApiConfiguration documentStoreApiConfiguration;
-	private final ConcordanceApiConfiguration concordanceApiConfiguration;
-    private final ConsumerConfiguration consumerConfiguration;
-    private final ProducerConfiguration producerConfiguration;
+	private boolean documentStoreApiEnabled;
+	private DocumentStoreApiConfiguration documentStoreApiConfiguration;
+    private boolean concordanceApiEnabled;
+	private ConcordanceApiConfiguration concordanceApiConfiguration;
+    private boolean messagingEndpointEnabled;
+    private ConsumerConfiguration consumerConfiguration;
+    private ProducerConfiguration producerConfiguration;
     private final List<BrandConfiguration> brands;
     private final List<VideoSiteConfiguration> videoSiteConfig;
     private final List<String> interactiveGraphicsWhiteList;
     private final String contentUriPrefix;
     private final String apiHost;
 
-    public MethodeArticleMapperConfiguration(@JsonProperty("consumer") ConsumerConfiguration consumerConfiguration,
+    public MethodeArticleMapperConfiguration(@JsonProperty("messagingEndpointEnabled") Boolean messagingEndpointEnabled,
+                                             @JsonProperty("consumer") ConsumerConfiguration consumerConfiguration,
                                              @JsonProperty("producer") ProducerConfiguration producerConfiguration,
+                                             @JsonProperty("concordanceApiEnabled") Boolean concordanceApiEnabled,
                                              @JsonProperty("concordanceApi") ConcordanceApiConfiguration concordanceApiConfiguration,
+                                             @JsonProperty("documentStoreApiEnabled") Boolean documentStoreApiEnabled,
                                              @JsonProperty("documentStoreApi") DocumentStoreApiConfiguration documentStoreApiConfiguration,
                                              @JsonProperty("brands") List<BrandConfiguration> brands,
                                              @JsonProperty("videoSiteConfig") List<VideoSiteConfiguration> videoSiteConfig,
@@ -30,26 +35,47 @@ public class MethodeArticleMapperConfiguration extends Configuration {
                                              @JsonProperty("contentUriPrefix") String contentUriPrefix,
                                              @JsonProperty("apiHost") String apiHost) {
 
-        this.documentStoreApiConfiguration = documentStoreApiConfiguration;
-		this.concordanceApiConfiguration=concordanceApiConfiguration;
+        if ((documentStoreApiEnabled == null) || documentStoreApiEnabled.booleanValue()) {
+            this.documentStoreApiEnabled = true;
+            this.documentStoreApiConfiguration = documentStoreApiConfiguration;
+        }
+        
+        if ((concordanceApiEnabled == null) || concordanceApiEnabled.booleanValue()) {
+            this.concordanceApiEnabled = true;
+            this.concordanceApiConfiguration=concordanceApiConfiguration;
+        }
+        
         this.brands = brands;
-        this.consumerConfiguration = consumerConfiguration;
-        this.producerConfiguration = producerConfiguration;
+        
+        if ((messagingEndpointEnabled == null) || messagingEndpointEnabled.booleanValue()) {
+            this.messagingEndpointEnabled = true;
+            this.consumerConfiguration = consumerConfiguration;
+            this.producerConfiguration = producerConfiguration;
+        }
+        
         this.videoSiteConfig = videoSiteConfig;
         this.interactiveGraphicsWhiteList = interactiveGraphicsWhiteList;
         this.contentUriPrefix = contentUriPrefix;
         this.apiHost = apiHost;
     }
+    
+    public boolean isConcordanceApiEnabled() {
+        return concordanceApiEnabled;
+    }
 
-	@NotNull
 	public ConcordanceApiConfiguration getConcordanceApiConfiguration() {
 		return concordanceApiConfiguration;
 	}
+	
+	public boolean isDocumentStoreApiEnabled() {
+	    return documentStoreApiEnabled;
+	}
+	
+	public DocumentStoreApiConfiguration getDocumentStoreApiConfiguration() {
+	    return documentStoreApiConfiguration;
+	}
 
-	@NotNull
-	public DocumentStoreApiConfiguration getDocumentStoreApiConfiguration() { return documentStoreApiConfiguration; }
-
-   @NotNull
+    @NotNull
     public List<BrandConfiguration> getBrandsConfiguration() {
         return brands;
     }
@@ -61,13 +87,15 @@ public class MethodeArticleMapperConfiguration extends Configuration {
     public List<String> getInteractiveGraphicsWhitelist() {
         return interactiveGraphicsWhiteList;
     }
+    
+    public boolean isMessagingEndpointEnabled() {
+        return messagingEndpointEnabled;
+    }
 
-    @NotNull
     public ConsumerConfiguration getConsumerConfiguration() {
         return consumerConfiguration;
     }
 
-    @NotNull
     public ProducerConfiguration getProducerConfiguration() {
         return producerConfiguration;
     }

--- a/src/main/java/com/ft/methodearticlemapper/exception/UnsupportedTransformationModeException.java
+++ b/src/main/java/com/ft/methodearticlemapper/exception/UnsupportedTransformationModeException.java
@@ -1,0 +1,19 @@
+package com.ft.methodearticlemapper.exception;
+
+import com.ft.methodearticlemapper.transformation.TransformationMode;
+
+@SuppressWarnings("serial")
+public class UnsupportedTransformationModeException
+        extends RuntimeException {
+
+    private final String uuid;
+
+    public UnsupportedTransformationModeException(String uuid, TransformationMode mode) {
+        super(String.format("Transformation mode %s is not available", mode));
+        this.uuid = uuid;
+    }
+
+    public String getUuid() {
+        return uuid;
+    }
+}

--- a/src/main/java/com/ft/methodearticlemapper/health/StandaloneHealthCheck.java
+++ b/src/main/java/com/ft/methodearticlemapper/health/StandaloneHealthCheck.java
@@ -1,0 +1,38 @@
+package com.ft.methodearticlemapper.health;
+
+import com.ft.platform.dropwizard.AdvancedHealthCheck;
+import com.ft.platform.dropwizard.AdvancedResult;
+
+public class StandaloneHealthCheck extends AdvancedHealthCheck {
+    private final String panicGuideUrl;
+    
+    public StandaloneHealthCheck(String panicGuideUrl) {
+        super("Service is up and running");
+        
+        this.panicGuideUrl = panicGuideUrl;
+    }
+
+    public AdvancedResult checkAdvanced() throws Exception {
+        return AdvancedResult.healthy();
+    }
+
+    @Override
+    protected int severity() {
+        return 1;
+    }
+
+    @Override
+    protected String businessImpact() {
+        return "No business impact";
+    }
+
+    @Override
+    protected String technicalSummary() {
+        return "This service is running without external dependencies.";
+    }
+
+    @Override
+    protected String panicGuideUrl() {
+        return panicGuideUrl;
+    }
+}

--- a/src/main/java/com/ft/methodearticlemapper/messaging/MessageProducingArticleMapper.java
+++ b/src/main/java/com/ft/methodearticlemapper/messaging/MessageProducingArticleMapper.java
@@ -5,6 +5,7 @@ import com.ft.messaging.standards.message.v1.Message;
 import com.ft.methodearticlemapper.exception.MethodeMarkedDeletedException;
 import com.ft.methodearticlemapper.model.EomFile;
 import com.ft.methodearticlemapper.transformation.EomFileProcessor;
+import com.ft.methodearticlemapper.transformation.TransformationMode;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,7 +35,7 @@ public class MessageProducingArticleMapper {
         Message message;
         try {
             message = messageBuilder.buildMessage(
-                    articleMapper.processPublication(methodeContent, transactionId, messageTimestamp)
+                    articleMapper.process(methodeContent, TransformationMode.PUBLISH, transactionId, messageTimestamp)
             );
         } catch (MethodeMarkedDeletedException e) {
             LOGGER.info("Article {} is marked as deleted.", methodeContent.getUuid());

--- a/src/main/java/com/ft/methodearticlemapper/resources/PostContentToTransformResource.java
+++ b/src/main/java/com/ft/methodearticlemapper/resources/PostContentToTransformResource.java
@@ -35,9 +35,6 @@ public class PostContentToTransformResource {
 
     private static final String CHARSET_UTF_8 = ";charset=utf-8";
 
-    // strictly this is an HTTP/2 response code, so there's no constant for it
-    private static final int SC_MISDIRECTED_REQUEST = 421;
-    
     private final EomFileProcessor eomFileProcessor;
 
     public PostContentToTransformResource(EomFileProcessor eomFileProcessor) {
@@ -99,7 +96,7 @@ public class PostContentToTransformResource {
                     .error(e.getMessage())
                     .exception(e);
         } catch (UnsupportedTransformationModeException e) {
-            throw ClientError.status(SC_MISDIRECTED_REQUEST)
+            throw ClientError.status(SC_NOT_FOUND)
                     .context(uuid)
                     .error(e.getMessage())
                     .exception(e);

--- a/src/main/java/com/ft/methodearticlemapper/resources/PostContentToTransformResource.java
+++ b/src/main/java/com/ft/methodearticlemapper/resources/PostContentToTransformResource.java
@@ -1,5 +1,9 @@
 package com.ft.methodearticlemapper.resources;
 
+import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
+import static org.apache.http.HttpStatus.SC_NOT_FOUND;
+import static org.apache.http.HttpStatus.SC_UNPROCESSABLE_ENTITY;
+
 import com.codahale.metrics.annotation.Timed;
 import com.ft.api.jaxrs.errors.ClientError;
 import com.ft.api.util.transactionid.TransactionIdUtils;
@@ -9,6 +13,7 @@ import com.ft.methodearticlemapper.exception.MethodeMarkedDeletedException;
 import com.ft.methodearticlemapper.exception.MethodeMissingBodyException;
 import com.ft.methodearticlemapper.exception.MethodeMissingFieldException;
 import com.ft.methodearticlemapper.exception.NotWebChannelException;
+import com.ft.methodearticlemapper.exception.UnsupportedTransformationModeException;
 import com.ft.methodearticlemapper.exception.UntransformableMethodeContentException;
 import com.ft.methodearticlemapper.model.EomFile;
 import com.ft.methodearticlemapper.transformation.EomFileProcessor;
@@ -30,6 +35,9 @@ public class PostContentToTransformResource {
 
     private static final String CHARSET_UTF_8 = ";charset=utf-8";
 
+    // strictly this is an HTTP/2 response code, so there's no constant for it
+    private static final int SC_MISDIRECTED_REQUEST = 421;
+    
     private final EomFileProcessor eomFileProcessor;
 
     public PostContentToTransformResource(EomFileProcessor eomFileProcessor) {
@@ -50,7 +58,14 @@ public class PostContentToTransformResource {
 		if (mode == null) {
 		    transformationMode = preview ? TransformationMode.PREVIEW : TransformationMode.PUBLISH;
 		} else {
-		    transformationMode = TransformationMode.valueOf(mode.toUpperCase());
+		    try {
+		        transformationMode = TransformationMode.valueOf(mode.toUpperCase());
+		    } catch (IllegalArgumentException e) {
+	            throw ClientError.status(SC_BAD_REQUEST)
+                                 .context(uuid)
+                                 .error(e.getMessage())
+                                 .exception(e);
+		    }
 		}
         // otherwise, mode trumps the preview flag if there is a mismatch
 		
@@ -62,24 +77,29 @@ public class PostContentToTransformResource {
             return eomFileProcessor.process(eomFile, mode, transactionId, new Date());
 
         } catch (MethodeMarkedDeletedException e) {
-            throw ClientError.status(404)
+            throw ClientError.status(SC_NOT_FOUND)
                     .context(uuid)
                     .reason(ErrorMessage.METHODE_FILE_NOT_FOUND)
                     .exception(e);
         } catch (NotWebChannelException e) {
-            throw ClientError.status(422)
+            throw ClientError.status(SC_UNPROCESSABLE_ENTITY)
                     .reason(ErrorMessage.NOT_WEB_CHANNEL)
                     .exception(e);
         } catch (MethodeMissingFieldException e) {
-            throw ClientError.status(422)
+            throw ClientError.status(SC_UNPROCESSABLE_ENTITY)
                     .error(String.format(ErrorMessage.METHODE_FIELD_MISSING.toString(), e.getFieldName()))
                     .exception(e);
         } catch (MethodeMissingBodyException | UntransformableMethodeContentException e) {
-            throw ClientError.status(422)
+            throw ClientError.status(SC_UNPROCESSABLE_ENTITY)
                     .error(e.getMessage())
                     .exception(e);
         } catch (MethodeContentNotEligibleForPublishException e) {
-            throw ClientError.status(422)
+            throw ClientError.status(SC_UNPROCESSABLE_ENTITY)
+                    .context(uuid)
+                    .error(e.getMessage())
+                    .exception(e);
+        } catch (UnsupportedTransformationModeException e) {
+            throw ClientError.status(SC_MISDIRECTED_REQUEST)
                     .context(uuid)
                     .error(e.getMessage())
                     .exception(e);
@@ -88,14 +108,14 @@ public class PostContentToTransformResource {
 
     private void validateUuid(String uuid) {
         if (uuid == null) {
-            throw ClientError.status(400).context(null).reason(ErrorMessage.UUID_REQUIRED).exception();
+            throw ClientError.status(SC_BAD_REQUEST).context(null).reason(ErrorMessage.UUID_REQUIRED).exception();
         }
         try {
             if (!UUID.fromString(uuid).toString().equals(uuid)) {
                 throw new IllegalArgumentException("Invalid UUID: " + uuid);
             }
         } catch (IllegalArgumentException iae) {
-            throw ClientError.status(400)
+            throw ClientError.status(SC_BAD_REQUEST)
                     .reason(ErrorMessage.INVALID_UUID)
                     .exception(iae);
         }

--- a/src/main/java/com/ft/methodearticlemapper/transformation/BodyProcessingFieldTransformer.java
+++ b/src/main/java/com/ft/methodearticlemapper/transformation/BodyProcessingFieldTransformer.java
@@ -12,10 +12,10 @@ public class BodyProcessingFieldTransformer implements FieldTransformer {
     }
 
     @Override
-    public String transform(String originalBody, String transactionId, Map.Entry<String, Object>... contextData) {
+    public String transform(String originalBody, String transactionId, TransformationMode mode, Map.Entry<String, Object>... contextData) {
         return bodyProcessorChain.process(
             originalBody,
-            new MappedDataBodyProcessingContext(transactionId, contextData));
+            new MappedDataBodyProcessingContext(transactionId, mode, contextData));
     }
 
 }

--- a/src/main/java/com/ft/methodearticlemapper/transformation/BodyProcessingFieldTransformerFactory.java
+++ b/src/main/java/com/ft/methodearticlemapper/transformation/BodyProcessingFieldTransformerFactory.java
@@ -17,7 +17,6 @@ import com.ft.bodyprocessing.richcontent.VideoMatcher;
 import com.ft.bodyprocessing.xml.StAXTransformingBodyProcessor;
 import com.ft.bodyprocessing.xml.dom.DOMTransformingBodyProcessor;
 import com.ft.bodyprocessing.xml.dom.XPathHandler;
-import com.ft.jerseyhttpwrapper.ResilientClient;
 import com.ft.methodearticlemapper.transformation.xslt.ModularXsltBodyProcessor;
 import com.ft.methodearticlemapper.transformation.xslt.XsltFile;
 import com.google.common.base.Charsets;
@@ -27,14 +26,14 @@ import com.sun.jersey.api.client.Client;
 
 public class BodyProcessingFieldTransformerFactory implements FieldTransformerFactory {
 
-	private ResilientClient documentStoreApiClient;
+	private Client documentStoreApiClient;
 	private URI documentStoreUri;
     private VideoMatcher videoMatcher;
     private InteractiveGraphicsMatcher interactiveGraphicsMatcher;
     private final Map<String,XPathHandler> xpathHandlers;
     
 
-	public BodyProcessingFieldTransformerFactory(final ResilientClient documentStoreApiClient,
+	public BodyProcessingFieldTransformerFactory(final Client documentStoreApiClient,
             final URI uri,
             final VideoMatcher videoMatcher,
             final InteractiveGraphicsMatcher interactiveGraphicsMatcher, Client concordanceApiClient, URI concordanceApiUri) {

--- a/src/main/java/com/ft/methodearticlemapper/transformation/BylineProcessingFieldTransformer.java
+++ b/src/main/java/com/ft/methodearticlemapper/transformation/BylineProcessingFieldTransformer.java
@@ -12,10 +12,10 @@ public class BylineProcessingFieldTransformer implements FieldTransformer {
     }
 
     @Override
-    public String transform(String originalBody, String transactionId, Map.Entry<String, Object>... contextData) {
+    public String transform(String originalBody, String transactionId, TransformationMode mode, Map.Entry<String, Object>... contextData) {
         return bodyProcessorChain.process(
             originalBody,
-            new MappedDataBodyProcessingContext(transactionId, contextData));
+            new MappedDataBodyProcessingContext(transactionId, mode, contextData));
     }
 
 }

--- a/src/main/java/com/ft/methodearticlemapper/transformation/EomFileProcessor.java
+++ b/src/main/java/com/ft/methodearticlemapper/transformation/EomFileProcessor.java
@@ -62,11 +62,6 @@ public class EomFileProcessor {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(EomFileProcessor.class);
 
-    enum TransformationMode {
-        PUBLISH,
-        PREVIEW
-    }
-
     interface Type {
         String CONTENT_PACKAGE = "ContentPackage";
         String ARTICLE = "Article";
@@ -178,7 +173,7 @@ public class EomFileProcessor {
 
         final String standfirst = Strings.nullToEmpty(xpath.evaluate(STANDFIRST_XPATH, value)).trim();
 
-        final String transformedBody = transformField(eomFile.getBody(), bodyTransformer, transactionId,
+        final String transformedBody = transformField(eomFile.getBody(), bodyTransformer, transactionId, mode,
             Maps.immutableEntry("uuid", uuid.toString()), Maps.immutableEntry("apiHost", apiHost));
         final String validatedBody = validateBody(mode, type, transformedBody, uuid);
 
@@ -190,7 +185,7 @@ public class EomFileProcessor {
         final String storyPackage = getStoryPackage(xpath, value, uuid);
 
         final String transformedByline = transformField(retrieveField(xpath, BYLINE_XPATH, eomFile.getValue()),
-                bylineTransformer, transactionId); //byline is optional
+                bylineTransformer, transactionId, mode); //byline is optional
 
         final Syndication canBeSyndicated = getSyndication(xpath, attributes);
         final AccessLevel accessLevel = getAccessLevel(xpath, attributes, uuid);
@@ -418,11 +413,12 @@ public class EomFileProcessor {
     private String transformField(final String originalFieldAsString,
         final FieldTransformer transformer,
         final String transactionId,
+        final TransformationMode mode,
         final Entry<String, Object>... contextData) {
 
         String transformedField = "";
         if (!Strings.isNullOrEmpty(originalFieldAsString)) {
-            transformedField = transformer.transform(originalFieldAsString, transactionId, contextData);
+            transformedField = transformer.transform(originalFieldAsString, transactionId, mode, contextData);
         }
         return transformedField;
     }

--- a/src/main/java/com/ft/methodearticlemapper/transformation/FieldTransformer.java
+++ b/src/main/java/com/ft/methodearticlemapper/transformation/FieldTransformer.java
@@ -7,6 +7,7 @@ public interface FieldTransformer {
     String transform(
         String originalField,
         String transactionId,
+        TransformationMode mode,
         Map.Entry<String, Object>... contextData);
 
 }

--- a/src/main/java/com/ft/methodearticlemapper/transformation/MappedDataBodyProcessingContext.java
+++ b/src/main/java/com/ft/methodearticlemapper/transformation/MappedDataBodyProcessingContext.java
@@ -6,14 +6,20 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
 
-public class MappedDataBodyProcessingContext extends DefaultTransactionIdBodyProcessingContext {
-
+public class MappedDataBodyProcessingContext
+    extends DefaultTransactionIdBodyProcessingContext
+    implements ModalBodyProcessingContext {
+  
+  private final TransformationMode mode;
   private final Map<String, Object> dataMap;
 
   public MappedDataBodyProcessingContext(
       final String transactionId,
+      final TransformationMode transformationMode,
       final Entry<String, Object>... contextData) {
+    
     super(transactionId);
+    this.mode = transformationMode;
     this.dataMap =
         Arrays
             .stream(contextData)
@@ -24,5 +30,8 @@ public class MappedDataBodyProcessingContext extends DefaultTransactionIdBodyPro
     final Object data = dataMap.get(contextKey);
     return expectedType.cast(data);
   }
-
+  
+  public TransformationMode getTransformationMode() {
+      return mode;
+  }
 }

--- a/src/main/java/com/ft/methodearticlemapper/transformation/MethodeLinksBodyProcessor.java
+++ b/src/main/java/com/ft/methodearticlemapper/transformation/MethodeLinksBodyProcessor.java
@@ -7,11 +7,11 @@ import com.ft.bodyprocessing.BodyProcessingContext;
 import com.ft.bodyprocessing.BodyProcessingException;
 import com.ft.bodyprocessing.BodyProcessor;
 import com.ft.bodyprocessing.TransactionIdBodyProcessingContext;
-import com.ft.jerseyhttpwrapper.ResilientClient;
 import com.ft.methodearticlemapper.exception.DocumentStoreApiInvalidRequestException;
 import com.ft.methodearticlemapper.exception.DocumentStoreApiUnavailableException;
 import com.ft.methodearticlemapper.exception.DocumentStoreApiUnmarshallingException;
 import com.ft.methodearticlemapper.model.Content;
+import com.sun.jersey.api.client.Client;
 import com.sun.jersey.api.client.ClientHandlerException;
 import com.sun.jersey.api.client.ClientResponse;
 import org.apache.commons.lang.StringUtils;
@@ -68,10 +68,10 @@ public class MethodeLinksBodyProcessor implements BodyProcessor {
     private static final String FT_COM_URL_REGEX = "^https*:\\/\\/www.ft.com\\/.*";
     private static final Pattern FT_COM_URL_REGEX_PATTERN = Pattern.compile(FT_COM_URL_REGEX);
 
-    private ResilientClient documentStoreApiClient;
+    private Client documentStoreApiClient;
     private URI uri;
 
-	public MethodeLinksBodyProcessor(ResilientClient documentStoreApiClient, URI uri) {
+	public MethodeLinksBodyProcessor(Client documentStoreApiClient, URI uri) {
 		this.documentStoreApiClient = documentStoreApiClient;
         this.uri = uri;
 	}

--- a/src/main/java/com/ft/methodearticlemapper/transformation/ModalBodyProcessingContext.java
+++ b/src/main/java/com/ft/methodearticlemapper/transformation/ModalBodyProcessingContext.java
@@ -1,0 +1,7 @@
+package com.ft.methodearticlemapper.transformation;
+
+import com.ft.bodyprocessing.BodyProcessingContext;
+
+public interface ModalBodyProcessingContext extends BodyProcessingContext {
+    TransformationMode getTransformationMode();
+}

--- a/src/main/java/com/ft/methodearticlemapper/transformation/ModalBodyProcessor.java
+++ b/src/main/java/com/ft/methodearticlemapper/transformation/ModalBodyProcessor.java
@@ -1,0 +1,27 @@
+package com.ft.methodearticlemapper.transformation;
+
+import com.ft.bodyprocessing.BodyProcessingContext;
+import com.ft.bodyprocessing.BodyProcessingException;
+import com.ft.bodyprocessing.BodyProcessor;
+
+import java.util.EnumSet;
+
+public class ModalBodyProcessor implements BodyProcessor {
+    private BodyProcessor processor;
+    private EnumSet<TransformationMode> allowedModes;
+    
+    public ModalBodyProcessor(BodyProcessor toWrap, EnumSet<TransformationMode> inModes) {
+        this.processor = toWrap;
+        this.allowedModes = inModes;
+    }
+    
+    @Override
+    public String process(String body, BodyProcessingContext bodyProcessingContext) throws BodyProcessingException {
+        if (!(bodyProcessingContext instanceof ModalBodyProcessingContext)) {
+            throw new IllegalArgumentException("Using a ModalBodyProcessor requires a ModalBodyProcessingContext.");
+        }
+        
+        TransformationMode mode = ((ModalBodyProcessingContext)bodyProcessingContext).getTransformationMode();
+        return allowedModes.contains(mode) ? processor.process(body, bodyProcessingContext) : body;
+    }
+}

--- a/src/main/java/com/ft/methodearticlemapper/transformation/TransformationMode.java
+++ b/src/main/java/com/ft/methodearticlemapper/transformation/TransformationMode.java
@@ -2,5 +2,6 @@ package com.ft.methodearticlemapper.transformation;
 
 public enum TransformationMode {
     PUBLISH,
-    PREVIEW
+    PREVIEW,
+    SUGGEST
 }

--- a/src/main/java/com/ft/methodearticlemapper/transformation/TransformationMode.java
+++ b/src/main/java/com/ft/methodearticlemapper/transformation/TransformationMode.java
@@ -1,0 +1,6 @@
+package com.ft.methodearticlemapper.transformation;
+
+public enum TransformationMode {
+    PUBLISH,
+    PREVIEW
+}

--- a/src/test/java/com/ft/methodearticlemapper/BodyProcessingStepDefs.java
+++ b/src/test/java/com/ft/methodearticlemapper/BodyProcessingStepDefs.java
@@ -49,6 +49,7 @@ import com.ft.methodearticlemapper.transformation.BodyProcessingFieldTransformer
 import com.ft.methodearticlemapper.transformation.FieldTransformer;
 import com.ft.methodearticlemapper.transformation.InteractiveGraphicsMatcher;
 import com.ft.methodearticlemapper.transformation.MethodeBodyTransformationXMLEventHandlerRegistry;
+import com.ft.methodearticlemapper.transformation.TransformationMode;
 import com.google.common.collect.ImmutableList;
 import com.sun.jersey.api.client.Client;
 import com.sun.jersey.api.client.ClientResponse;
@@ -227,12 +228,12 @@ public class BodyProcessingStepDefs {
 
     @When("^I transform it into our Content Store format$")
     public void i_transform_it_into_our_content_store_format() throws Throwable {
-        transformedBodyText = bodyTransformer.transform(methodeBodyText, TRANSACTION_ID);
+        transformedBodyText = bodyTransformer.transform(methodeBodyText, TRANSACTION_ID, TransformationMode.PUBLISH);
     }
 
     @When("^I transform it$")
     public void I_transform_it() throws Throwable {
-        transformedBodyText = bodyTransformer.transform(methodeBodyText, TRANSACTION_ID);
+        transformedBodyText = bodyTransformer.transform(methodeBodyText, TRANSACTION_ID, TransformationMode.PUBLISH);
     }
     @Then("^it is left unmodified$")
     public void it_is_left_unmodified() {
@@ -322,7 +323,7 @@ public class BodyProcessingStepDefs {
         char[] chars = Character.toChars(codePointInt);
         String expected = "<body>" + TEXT  + new String(chars) + "</body>";
         methodeBodyText = "<body>" + TEXT  +  entity + "</body>";
-        transformedBodyText = bodyTransformer.transform(methodeBodyText, TRANSACTION_ID);
+        transformedBodyText = bodyTransformer.transform(methodeBodyText, TRANSACTION_ID, TransformationMode.PUBLISH);
         assertThat(transformedBodyText, is(expected));
     }
 
@@ -338,7 +339,7 @@ public class BodyProcessingStepDefs {
 
     @When("^it is transformed, (.+) becomes (.+)$")
     public void the_before_becomes_after(String before, String after) throws Throwable {
-        transformedBodyText = bodyTransformer.transform(wrapped(before), TRANSACTION_ID);
+        transformedBodyText = bodyTransformer.transform(wrapped(before), TRANSACTION_ID, TransformationMode.PUBLISH);
 
         Diff diff = new Diff(wrapped(after), transformedBodyText);
         diff.overrideElementQualifier(new ElementNameAndTextQualifier());

--- a/src/test/java/com/ft/methodearticlemapper/health/StandaloneHealthCheckTest.java
+++ b/src/test/java/com/ft/methodearticlemapper/health/StandaloneHealthCheckTest.java
@@ -1,0 +1,22 @@
+package com.ft.methodearticlemapper.health;
+
+import com.ft.platform.dropwizard.AdvancedHealthCheck;
+import com.ft.platform.dropwizard.AdvancedResult;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class StandaloneHealthCheckTest {
+    @Test
+    public void thatHealthCheckShouldPass() throws Exception {
+        String url = "http://www.example.com/panic.html";
+        AdvancedHealthCheck hc = new StandaloneHealthCheck(url);
+        AdvancedResult actual = hc.executeAdvanced();
+
+        assertThat(actual.status(), is(equalTo(AdvancedResult.Status.OK)));
+        assertThat(((StandaloneHealthCheck)hc).panicGuideUrl(), is(equalTo(url)));
+    }
+}

--- a/src/test/java/com/ft/methodearticlemapper/messaging/MessageProducingArticleMapperTest.java
+++ b/src/test/java/com/ft/methodearticlemapper/messaging/MessageProducingArticleMapperTest.java
@@ -6,6 +6,7 @@ import com.ft.messaging.standards.message.v1.Message;
 import com.ft.methodearticlemapper.exception.MethodeMarkedDeletedException;
 import com.ft.methodearticlemapper.model.EomFile;
 import com.ft.methodearticlemapper.transformation.EomFileProcessor;
+import com.ft.methodearticlemapper.transformation.TransformationMode;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -51,7 +52,7 @@ public class MessageProducingArticleMapperTest {
         Content mappedArticle = new Content.Builder()
                 .withUuid(UUID.randomUUID())
                 .build();
-        when(mapper.processPublication(any(), eq("tid"), eq(lastModified))).thenReturn(mappedArticle);
+        when(mapper.process(any(), eq(TransformationMode.PUBLISH), eq("tid"), eq(lastModified))).thenReturn(mappedArticle);
 
         msgProducingArticleMapper.mapArticle(new EomFile.Builder().build(), "tid", lastModified);
 
@@ -62,7 +63,7 @@ public class MessageProducingArticleMapperTest {
     public void thatMessageWithContentIsSentToQueue() {
         Content mockedContent = mock(Content.class);
         Message mockedMessage = mock(Message.class);
-        when(mapper.processPublication(any(), anyString(), any())).thenReturn(mockedContent);
+        when(mapper.process(any(), eq(TransformationMode.PUBLISH), anyString(), any())).thenReturn(mockedContent);
         when(messageBuilder.buildMessage(mockedContent)).thenReturn(mockedMessage);
 
         msgProducingArticleMapper.mapArticle(new EomFile.Builder().build(), "tid", new Date());
@@ -77,7 +78,7 @@ public class MessageProducingArticleMapperTest {
         String uuid = UUID.randomUUID().toString();
         Message deletedContentMsg = mock(Message.class);
 
-        when(mapper.processPublication(any(), anyString(), any())).thenThrow(MethodeMarkedDeletedException.class);
+        when(mapper.process(any(), eq(TransformationMode.PUBLISH), anyString(), any())).thenThrow(MethodeMarkedDeletedException.class);
         when(messageBuilder.buildMessageForDeletedMethodeContent(uuid, tid, date)).thenReturn(deletedContentMsg);
 
         msgProducingArticleMapper.mapArticle(new EomFile.Builder().withUuid(uuid).build(), tid, date);

--- a/src/test/java/com/ft/methodearticlemapper/resources/ArticlePreviewTransformationTest.java
+++ b/src/test/java/com/ft/methodearticlemapper/resources/ArticlePreviewTransformationTest.java
@@ -11,6 +11,7 @@ import com.ft.methodearticlemapper.methode.ContentSource;
 import com.ft.methodearticlemapper.model.EomFile;
 import com.ft.methodearticlemapper.transformation.EomFileProcessor;
 import com.ft.methodearticlemapper.transformation.FieldTransformer;
+import com.ft.methodearticlemapper.transformation.TransformationMode;
 
 import org.hamcrest.Matchers;
 import org.junit.Before;
@@ -71,7 +72,7 @@ public class ArticlePreviewTransformationTest {
         UUID expectedUuid = UUID.randomUUID();
         EomFile testEomFile = articlePreviewMinimalEomFile(expectedUuid.toString());
 
-        Content actualContent = postContentToTransformResource.map(testEomFile, IS_PREVIEW, httpHeaders);
+        Content actualContent = postContentToTransformResource.map(testEomFile, IS_PREVIEW, null, httpHeaders);
 
         assertThat(expectedUuid.toString(), equalTo(actualContent.getUuid()));
         assertThat(TRANSACTION_ID, equalTo(actualContent.getPublishReference()));
@@ -91,7 +92,7 @@ public class ArticlePreviewTransformationTest {
 
         when(eomFile.getType()).thenReturn(INVALID_EOM_FILE_TYPE);
         when(eomFile.getUuid()).thenReturn(randomUuid);
-        eomFileProcessor.processPreview(eomFile, TRANSACTION_ID, new Date());
+        eomFileProcessor.process(eomFile, TransformationMode.PREVIEW, TRANSACTION_ID, new Date());
     }
 
     /* In article preview we don't care about systemAttributes, usageTickets & lastModified date */

--- a/src/test/java/com/ft/methodearticlemapper/resources/ArticlePreviewTransformationTest.java
+++ b/src/test/java/com/ft/methodearticlemapper/resources/ArticlePreviewTransformationTest.java
@@ -19,6 +19,7 @@ import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Date;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -58,7 +59,7 @@ public class ArticlePreviewTransformationTest {
         Map<ContentSource, Brand> contentSourceBrandMap = new HashMap<>();
         contentSourceBrandMap.put(ContentSource.FT, new Brand(ARBITRARY_BRAND));
 
-        eomFileProcessor = new EomFileProcessor(bodyTransformer, bylineTransformer, htmlFieldProcessor, contentSourceBrandMap, API_HOST);
+        eomFileProcessor = new EomFileProcessor(EnumSet.allOf(TransformationMode.class), bodyTransformer, bylineTransformer, htmlFieldProcessor, contentSourceBrandMap, API_HOST);
         postContentToTransformResource= new PostContentToTransformResource(eomFileProcessor);
 
         when(httpHeaders.getRequestHeader(TransactionIdUtils.TRANSACTION_ID_HEADER)).thenReturn(Arrays.asList(TRANSACTION_ID));

--- a/src/test/java/com/ft/methodearticlemapper/resources/PostContentToTransformResourceForPreviewUnhappyPathsTest.java
+++ b/src/test/java/com/ft/methodearticlemapper/resources/PostContentToTransformResourceForPreviewUnhappyPathsTest.java
@@ -6,6 +6,7 @@ import com.ft.api.util.transactionid.TransactionIdUtils;
 import com.ft.methodearticlemapper.exception.UnsupportedEomTypeException;
 import com.ft.methodearticlemapper.model.EomFile;
 import com.ft.methodearticlemapper.transformation.EomFileProcessor;
+import com.ft.methodearticlemapper.transformation.TransformationMode;
 
 import org.apache.http.HttpStatus;
 import org.junit.Before;
@@ -56,7 +57,7 @@ public class PostContentToTransformResourceForPreviewUnhappyPathsTest {
     public void shouldThrow400ExceptionWhenNoUuidPassed() {
         try {
             EomFile eomFile = Mockito.mock(EomFile.class);
-            postContentToTransformResource.map(eomFile, IS_PREVIEW_TRUE, httpHeaders);
+            postContentToTransformResource.map(eomFile, IS_PREVIEW_TRUE, null, httpHeaders);
             fail("No exception was thrown, but expected one.");
         } catch (WebApplicationClientException wace) {
             assertThat(((ErrorEntity)wace.getResponse().getEntity()).getMessage(),
@@ -73,7 +74,7 @@ public class PostContentToTransformResourceForPreviewUnhappyPathsTest {
     public void shouldThrow400ExceptionWhenInvalidUuidPassed() {
         try {
             EomFile eomFile = ArticlePreviewTransformationTest.articlePreviewMinimalEomFile("invalid_uuid");
-            postContentToTransformResource.map(eomFile, IS_PREVIEW_TRUE, httpHeaders);
+            postContentToTransformResource.map(eomFile, IS_PREVIEW_TRUE, null, httpHeaders);
             fail("No exception was thrown, but expected one.");
         } catch (WebApplicationClientException wace) {
             assertThat(((ErrorEntity)wace.getResponse().getEntity()).getMessage(),
@@ -90,10 +91,10 @@ public class PostContentToTransformResourceForPreviewUnhappyPathsTest {
     public void shouldThrow422ExceptionWhenPreviewNotEligibleForPublishing() {
         UUID randomUuid = UUID.randomUUID();
         when(eomFile.getUuid()).thenReturn(randomUuid.toString());
-        when(eomFileProcessor.processPreview(eq(eomFile), eq(TRANSACTION_ID), any())).
+        when(eomFileProcessor.process(eq(eomFile), eq(TransformationMode.PREVIEW), eq(TRANSACTION_ID), any())).
                 thenThrow(new UnsupportedEomTypeException(randomUuid, INVALID_TYPE));
         try {
-            postContentToTransformResource.map(eomFile, IS_PREVIEW_TRUE, httpHeaders);
+            postContentToTransformResource.map(eomFile, IS_PREVIEW_TRUE, null, httpHeaders);
             fail("No exception was thrown, but expected one.");
         } catch (WebApplicationClientException wace) {
             assertThat(((ErrorEntity)wace.getResponse().getEntity()).getMessage(),

--- a/src/test/java/com/ft/methodearticlemapper/resources/PostContentToTransformResourceForPublicationUnhappyPathsTest.java
+++ b/src/test/java/com/ft/methodearticlemapper/resources/PostContentToTransformResourceForPublicationUnhappyPathsTest.java
@@ -10,6 +10,7 @@ import com.ft.methodearticlemapper.exception.MethodeMissingFieldException;
 import com.ft.methodearticlemapper.exception.NotWebChannelException;
 import com.ft.methodearticlemapper.exception.SourceNotEligibleForPublishException;
 import com.ft.methodearticlemapper.exception.UnsupportedEomTypeException;
+import com.ft.methodearticlemapper.exception.UnsupportedTransformationModeException;
 import com.ft.methodearticlemapper.exception.UntransformableMethodeContentException;
 import com.ft.methodearticlemapper.exception.WorkflowStatusNotEligibleForPublishException;
 import com.ft.methodearticlemapper.model.EomFile;
@@ -265,6 +266,21 @@ public class PostContentToTransformResourceForPublicationUnhappyPathsTest {
            assertThat(((ErrorEntity)e.getResponse().getEntity()).getMessage(),
                    containsString("it's blank"));
            assertThat(e.getResponse().getStatus(), equalTo(HttpStatus.SC_UNPROCESSABLE_ENTITY));
+       }
+   }
+
+   @Test
+   public void thatUnsupportedTransformationModeIsRejected() {
+       when(eomFileProcessor.process(eq(eomFile), eq(TransformationMode.PUBLISH), eq(TRANSACTION_ID), any())).
+           thenThrow(new UnsupportedTransformationModeException(uuid.toString(), TransformationMode.PUBLISH));
+       
+       try {
+           postContentToTransformResource.map(eomFile, false, TransformationMode.PUBLISH.toString(), httpHeaders);
+           fail("No exception was thrown, but expected one.");
+       } catch (WebApplicationClientException e) {
+           assertThat(((ErrorEntity)e.getResponse().getEntity()).getMessage(),
+               containsString("Transformation mode PUBLISH is not available"));
+           assertThat(e.getResponse().getStatus(), equalTo(421));
        }
    }
 }

--- a/src/test/java/com/ft/methodearticlemapper/resources/PostContentToTransformResourceForPublicationUnhappyPathsTest.java
+++ b/src/test/java/com/ft/methodearticlemapper/resources/PostContentToTransformResourceForPublicationUnhappyPathsTest.java
@@ -14,6 +14,7 @@ import com.ft.methodearticlemapper.exception.UntransformableMethodeContentExcept
 import com.ft.methodearticlemapper.exception.WorkflowStatusNotEligibleForPublishException;
 import com.ft.methodearticlemapper.model.EomFile;
 import com.ft.methodearticlemapper.transformation.EomFileProcessor;
+import com.ft.methodearticlemapper.transformation.TransformationMode;
 
 import org.apache.http.HttpStatus;
 import org.junit.Before;
@@ -68,7 +69,7 @@ public class PostContentToTransformResourceForPublicationUnhappyPathsTest {
     public void shouldThrow400ExceptionWhenNoUuidPassed() {
         try {
             EomFile eomFile = Mockito.mock(EomFile.class);
-            postContentToTransformResource.map(eomFile, IS_PREVIEW_FALSE, httpHeaders);
+            postContentToTransformResource.map(eomFile, IS_PREVIEW_FALSE, null, httpHeaders);
             fail("No exception was thrown, but expected one.");
         } catch (WebApplicationClientException wace) {
             assertThat(((ErrorEntity)wace.getResponse().getEntity()).getMessage(),
@@ -85,7 +86,7 @@ public class PostContentToTransformResourceForPublicationUnhappyPathsTest {
     public void shouldThrow400ExceptionWhenInvalidUuidPassed() {
         try {
             EomFile eomFile = ArticlePreviewTransformationTest.articlePreviewMinimalEomFile("invalid_uuid");
-            postContentToTransformResource.map(eomFile, IS_PREVIEW_FALSE, httpHeaders);
+            postContentToTransformResource.map(eomFile, IS_PREVIEW_FALSE, null, httpHeaders);
             fail("No exception was thrown, but expected one.");
         } catch (WebApplicationClientException wace) {
             assertThat(((ErrorEntity)wace.getResponse().getEntity()).getMessage(),
@@ -100,9 +101,9 @@ public class PostContentToTransformResourceForPublicationUnhappyPathsTest {
      */
     @Test
     public void shouldThrow404ExceptionWhenContentIsMarkedAsDeletedInMethode() {
-        when(eomFileProcessor.processPublication(eq(eomFile), eq(TRANSACTION_ID), any())).thenThrow(new MethodeMarkedDeletedException(uuid));
+        when(eomFileProcessor.process(eq(eomFile), eq(TransformationMode.PUBLISH), eq(TRANSACTION_ID), any())).thenThrow(new MethodeMarkedDeletedException(uuid));
         try {
-            postContentToTransformResource.map(eomFile, false, httpHeaders);
+            postContentToTransformResource.map(eomFile, false, null, httpHeaders);
             fail("No exception was thrown, but expected one.");
         } catch (WebApplicationClientException wace) {
             assertThat(((ErrorEntity)wace.getResponse().getEntity()).getMessage(),
@@ -118,10 +119,10 @@ public class PostContentToTransformResourceForPublicationUnhappyPathsTest {
     @Test
     public void shouldThrow422ExceptionWhenPublicationNotEligibleForPublishing() {
 
-        when(eomFileProcessor.processPublication(eq(eomFile), eq(TRANSACTION_ID), any())).
+        when(eomFileProcessor.process(eq(eomFile), eq(TransformationMode.PUBLISH), eq(TRANSACTION_ID), any())).
                 thenThrow(new UnsupportedEomTypeException(uuid, "EOM::DistortedStory"));
         try {
-            postContentToTransformResource.map(eomFile, false, httpHeaders);
+            postContentToTransformResource.map(eomFile, false, null, httpHeaders);
             fail("No exception was thrown, but expected one.");
         } catch (WebApplicationClientException wace) {
             assertThat(((ErrorEntity)wace.getResponse().getEntity()).getMessage(),
@@ -138,10 +139,10 @@ public class PostContentToTransformResourceForPublicationUnhappyPathsTest {
     public void shouldThrow422ExceptionWhenEmbargoDateInTheFuture() {
         Date embargoDate = new Date();
 
-        when(eomFileProcessor.processPublication(eq(eomFile), eq(TRANSACTION_ID), any())).
+        when(eomFileProcessor.process(eq(eomFile), eq(TransformationMode.PUBLISH), eq(TRANSACTION_ID), any())).
                 thenThrow(new EmbargoDateInTheFutureException(uuid, embargoDate));
         try {
-            postContentToTransformResource.map(eomFile, IS_PREVIEW_FALSE, httpHeaders);
+            postContentToTransformResource.map(eomFile, IS_PREVIEW_FALSE, null, httpHeaders);
             fail("No exception was thrown, but expected one.");
         } catch (WebApplicationClientException wace) {
             assertThat(((ErrorEntity)wace.getResponse().getEntity()).getMessage(),
@@ -157,10 +158,10 @@ public class PostContentToTransformResourceForPublicationUnhappyPathsTest {
     @Test
     public void shouldThrow422ExceptionWhenNotWebChannel() {
 
-        when(eomFileProcessor.processPublication(eq(eomFile), eq(TRANSACTION_ID), any())).
+        when(eomFileProcessor.process(eq(eomFile), eq(TransformationMode.PUBLISH), eq(TRANSACTION_ID), any())).
                 thenThrow(new NotWebChannelException(uuid));
         try {
-            postContentToTransformResource.map(eomFile, IS_PREVIEW_FALSE, httpHeaders);
+            postContentToTransformResource.map(eomFile, IS_PREVIEW_FALSE, null, httpHeaders);
             fail("No exception was thrown, but expected one.");
         } catch (WebApplicationClientException wace) {
             assertThat(((ErrorEntity)wace.getResponse().getEntity()).getMessage(),
@@ -176,10 +177,10 @@ public class PostContentToTransformResourceForPublicationUnhappyPathsTest {
     @Test
     public void shouldThrow422ExceptionWhenSourceNotFt() {
         final String sourceOtherThanFt = "Pepsi";
-        when(eomFileProcessor.processPublication(eq(eomFile), eq(TRANSACTION_ID), any())).
+        when(eomFileProcessor.process(eq(eomFile), eq(TransformationMode.PUBLISH), eq(TRANSACTION_ID), any())).
                 thenThrow(new SourceNotEligibleForPublishException(uuid, sourceOtherThanFt));
         try {
-            postContentToTransformResource.map(eomFile, IS_PREVIEW_FALSE, httpHeaders);
+            postContentToTransformResource.map(eomFile, IS_PREVIEW_FALSE, null, httpHeaders);
             fail("No exception was thrown, but expected one.");
         } catch (WebApplicationClientException wace) {
             assertThat(((ErrorEntity)wace.getResponse().getEntity()).getMessage(),
@@ -196,10 +197,10 @@ public class PostContentToTransformResourceForPublicationUnhappyPathsTest {
     public void shouldThrow422ExceptionWhenWorkflowStatusNotEligibleForPublishing() {
 
         final String workflowStatusNotEligibleForPublishing = "Story/Edit";
-        when(eomFileProcessor.processPublication(eq(eomFile), eq(TRANSACTION_ID), any())).
+        when(eomFileProcessor.process(eq(eomFile), eq(TransformationMode.PUBLISH), eq(TRANSACTION_ID), any())).
                 thenThrow(new WorkflowStatusNotEligibleForPublishException(uuid, workflowStatusNotEligibleForPublishing));
         try {
-            postContentToTransformResource.map(eomFile, IS_PREVIEW_FALSE, httpHeaders);
+            postContentToTransformResource.map(eomFile, IS_PREVIEW_FALSE, null, httpHeaders);
             fail("No exception was thrown, but expected one.");
         } catch (WebApplicationClientException wace) {
             assertThat(((ErrorEntity)wace.getResponse().getEntity()).getMessage(),
@@ -216,10 +217,10 @@ public class PostContentToTransformResourceForPublicationUnhappyPathsTest {
     @Test
     public void shouldThrow422ExceptionWhenMethodeFieldMissing() {
         final String missingField = "publishedDate";
-        when(eomFileProcessor.processPublication(eq(eomFile), eq(TRANSACTION_ID), any())).
+        when(eomFileProcessor.process(eq(eomFile), eq(TransformationMode.PUBLISH), eq(TRANSACTION_ID), any())).
                 thenThrow(new MethodeMissingFieldException(uuid, missingField));
         try {
-            postContentToTransformResource.map(eomFile, IS_PREVIEW_FALSE, httpHeaders);
+            postContentToTransformResource.map(eomFile, IS_PREVIEW_FALSE, null, httpHeaders);
             fail("No exception was thrown, but expected one.");
         } catch (WebApplicationClientException wace) {
             assertThat(((ErrorEntity)wace.getResponse().getEntity()).getMessage(),
@@ -236,10 +237,10 @@ public class PostContentToTransformResourceForPublicationUnhappyPathsTest {
      */
     @Test
     public void shouldThrow422ExceptionWhenMethodeBodyMissing() {
-        when(eomFileProcessor.processPublication(eq(eomFile), eq(TRANSACTION_ID), any())).
+        when(eomFileProcessor.process(eq(eomFile), eq(TransformationMode.PUBLISH), eq(TRANSACTION_ID), any())).
                 thenThrow(new MethodeMissingBodyException(uuid));
         try {
-            postContentToTransformResource.map(eomFile, IS_PREVIEW_FALSE, httpHeaders);
+            postContentToTransformResource.map(eomFile, IS_PREVIEW_FALSE, null, httpHeaders);
             fail("No exception was thrown, but expected one.");
         } catch (WebApplicationClientException e) {
             assertThat(((ErrorEntity)e.getResponse().getEntity()).getMessage(),
@@ -255,10 +256,10 @@ public class PostContentToTransformResourceForPublicationUnhappyPathsTest {
     */
    @Test
    public void shouldThrow422ExceptionWhenMethodeBodyBlankAfterTransformation() {
-       when(eomFileProcessor.processPublication(eq(eomFile), eq(TRANSACTION_ID), any())).
+       when(eomFileProcessor.process(eq(eomFile), eq(TransformationMode.PUBLISH), eq(TRANSACTION_ID), any())).
                thenThrow(new UntransformableMethodeContentException(uuid.toString(), "it's blank"));
        try {
-           postContentToTransformResource.map(eomFile, IS_PREVIEW_FALSE, httpHeaders);
+           postContentToTransformResource.map(eomFile, IS_PREVIEW_FALSE, null, httpHeaders);
            fail("No exception was thrown, but expected one.");
        } catch (WebApplicationClientException e) {
            assertThat(((ErrorEntity)e.getResponse().getEntity()).getMessage(),

--- a/src/test/java/com/ft/methodearticlemapper/resources/PostContentToTransformResourceForPublicationUnhappyPathsTest.java
+++ b/src/test/java/com/ft/methodearticlemapper/resources/PostContentToTransformResourceForPublicationUnhappyPathsTest.java
@@ -280,7 +280,7 @@ public class PostContentToTransformResourceForPublicationUnhappyPathsTest {
        } catch (WebApplicationClientException e) {
            assertThat(((ErrorEntity)e.getResponse().getEntity()).getMessage(),
                containsString("Transformation mode PUBLISH is not available"));
-           assertThat(e.getResponse().getStatus(), equalTo(421));
+           assertThat(e.getResponse().getStatus(), equalTo(HttpStatus.SC_NOT_FOUND));
        }
    }
 }

--- a/src/test/java/com/ft/methodearticlemapper/resources/PostContentToTransformResourceHappyPathsTest.java
+++ b/src/test/java/com/ft/methodearticlemapper/resources/PostContentToTransformResourceHappyPathsTest.java
@@ -3,6 +3,8 @@ package com.ft.methodearticlemapper.resources;
 import com.ft.api.util.transactionid.TransactionIdUtils;
 import com.ft.methodearticlemapper.model.EomFile;
 import com.ft.methodearticlemapper.transformation.EomFileProcessor;
+import com.ft.methodearticlemapper.transformation.TransformationMode;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -42,8 +44,8 @@ public class PostContentToTransformResourceHappyPathsTest {
      */
     @Test
     public void previewProcessedOk() {
-        postContentToTransformResource.map(eomFile, true, httpHeaders);
-        verify(eomFileProcessor, times(1)).processPreview(eq(eomFile), eq(TRANSACTION_ID), any());
+        postContentToTransformResource.map(eomFile, true, null, httpHeaders);
+        verify(eomFileProcessor, times(1)).process(eq(eomFile), eq(TransformationMode.PREVIEW), eq(TRANSACTION_ID), any());
     }
 
     /**
@@ -51,8 +53,8 @@ public class PostContentToTransformResourceHappyPathsTest {
      */
     @Test
     public void publicationProcessedOk() {
-        postContentToTransformResource.map(eomFile, false, httpHeaders);
-        verify(eomFileProcessor, times(1)).processPublication(eq(eomFile), eq(TRANSACTION_ID), any());
+        postContentToTransformResource.map(eomFile, false, null, httpHeaders);
+        verify(eomFileProcessor, times(1)).process(eq(eomFile), eq(TransformationMode.PUBLISH), eq(TRANSACTION_ID), any());
     }
 
 }

--- a/src/test/java/com/ft/methodearticlemapper/resources/PostContentToTransformResourceTest.java
+++ b/src/test/java/com/ft/methodearticlemapper/resources/PostContentToTransformResourceTest.java
@@ -1,5 +1,6 @@
 package com.ft.methodearticlemapper.resources;
 
+import com.ft.api.jaxrs.errors.WebApplicationClientException;
 import com.ft.api.util.transactionid.TransactionIdUtils;
 import com.ft.methodearticlemapper.model.EomFile;
 import com.ft.methodearticlemapper.transformation.EomFileProcessor;
@@ -60,7 +61,7 @@ public class PostContentToTransformResourceTest {
         verify(eomFileProcessor).process(eq(eomFile), eq(TransformationMode.SUGGEST), eq(TRANSACTION_ID), any());
     }
 
-    @Test(expected=IllegalArgumentException.class)
+    @Test(expected=WebApplicationClientException.class)
     public void thatModeQueryParameterIsValidated() {
         postContentToTransformResource.map(eomFile, false, "foobar", httpHeaders);
     }

--- a/src/test/java/com/ft/methodearticlemapper/resources/PostContentToTransformResourceTest.java
+++ b/src/test/java/com/ft/methodearticlemapper/resources/PostContentToTransformResourceTest.java
@@ -3,12 +3,12 @@ package com.ft.methodearticlemapper.resources;
 import com.ft.api.util.transactionid.TransactionIdUtils;
 import com.ft.methodearticlemapper.model.EomFile;
 import com.ft.methodearticlemapper.transformation.EomFileProcessor;
+import com.ft.methodearticlemapper.transformation.TransformationMode;
 
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Arrays;
-import java.util.Date;
 import java.util.UUID;
 
 import javax.ws.rs.core.HttpHeaders;
@@ -40,18 +40,42 @@ public class PostContentToTransformResourceTest {
     @Test
     public void thatIfMapPreviewParamIsTruePreviewProcessingIsTriggered() {
         boolean preview = true;
-        postContentToTransformResource.map(eomFile, preview, httpHeaders);
+        postContentToTransformResource.map(eomFile, preview, null, httpHeaders);
 
-        verify(eomFileProcessor).processPreview(eq(eomFile),eq(TRANSACTION_ID), any());
-        verify(eomFileProcessor, never()).processPublication(any(), any(), any());
+        verify(eomFileProcessor).process(eq(eomFile), eq(TransformationMode.PREVIEW), eq(TRANSACTION_ID), any());
+        verify(eomFileProcessor, never()).process(any(), eq(TransformationMode.PUBLISH), any(), any());
     }
 
     @Test
-    public void thatIfMapPreviewParamIsFalsePublicationProcessingIsTriggered() {
-        boolean notPreview = false;
-        postContentToTransformResource.map(eomFile, notPreview, httpHeaders);
+    public void thatModeQueryParameterIsPassedThrough() {
+        postContentToTransformResource.map(eomFile, false, TransformationMode.SUGGEST.toString().toLowerCase(), httpHeaders);
 
-        verify(eomFileProcessor).processPublication(eq(eomFile),eq(TRANSACTION_ID), any());
-        verify(eomFileProcessor, never()).processPreview(any(), any(), any());
+        verify(eomFileProcessor).process(eq(eomFile), eq(TransformationMode.SUGGEST), eq(TRANSACTION_ID), any());
+    }
+
+    @Test
+    public void thatModeQueryParameterIsCaseInsensitive() {
+        postContentToTransformResource.map(eomFile, false, TransformationMode.SUGGEST.toString(), httpHeaders);
+
+        verify(eomFileProcessor).process(eq(eomFile), eq(TransformationMode.SUGGEST), eq(TRANSACTION_ID), any());
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void thatModeQueryParameterIsValidated() {
+        postContentToTransformResource.map(eomFile, false, "foobar", httpHeaders);
+    }
+
+    @Test
+    public void thatModeQueryParameterTrumpsConflictingPreviewFlagFalse() {
+        postContentToTransformResource.map(eomFile, false, TransformationMode.PREVIEW.toString().toLowerCase(), httpHeaders);
+
+        verify(eomFileProcessor).process(eq(eomFile), eq(TransformationMode.PREVIEW), eq(TRANSACTION_ID), any());
+    }
+
+    @Test
+    public void thatModeQueryParameterTrumpsConflictingPreviewFlagTrue() {
+        postContentToTransformResource.map(eomFile, true, TransformationMode.PUBLISH.toString().toLowerCase(), httpHeaders);
+
+        verify(eomFileProcessor).process(eq(eomFile), eq(TransformationMode.PUBLISH), eq(TRANSACTION_ID), any());
     }
 }

--- a/src/test/java/com/ft/methodearticlemapper/transformation/BodyProcessingFieldTransformerFactoryTest.java
+++ b/src/test/java/com/ft/methodearticlemapper/transformation/BodyProcessingFieldTransformerFactoryTest.java
@@ -1178,7 +1178,7 @@ public class BodyProcessingFieldTransformerFactoryTest {
 				bodyTransformer
 						.transform(
 								bodyWithImageSets,
-								TRANSACTION_ID,
+								TRANSACTION_ID, TransformationMode.PUBLISH,
 								Maps.immutableEntry("uuid", articleUuid));
 		final UUID firstImageSetUuid = GenerateV3UUID.singleDigested(articleUuid + FIRST_EMBEDDED_IMAGE_SET_ID);
 		final UUID secondImageSetUuid = GenerateV3UUID.singleDigested(articleUuid + SECOND_EMBEDDED_IMAGE_SET_ID);
@@ -1258,7 +1258,7 @@ public class BodyProcessingFieldTransformerFactoryTest {
 	}
 
     private void checkTransformation(String originalBody, String expectedTransformedBody) {
-        String actualTransformedBody = bodyTransformer.transform(originalBody, TRANSACTION_ID);
+        String actualTransformedBody = bodyTransformer.transform(originalBody, TRANSACTION_ID, TransformationMode.PUBLISH);
 
         System.out.println("TRANSFORMED BODY:\n" + actualTransformedBody);
 
@@ -1266,7 +1266,7 @@ public class BodyProcessingFieldTransformerFactoryTest {
     }
 
     private void checkTransformationToEmpty(String originalBody) {
-        String actualTransformedBody = bodyTransformer.transform(originalBody, TRANSACTION_ID);
+        String actualTransformedBody = bodyTransformer.transform(originalBody, TRANSACTION_ID, TransformationMode.PUBLISH);
         assertThat(actualTransformedBody, is(""));
     }
     

--- a/src/test/java/com/ft/methodearticlemapper/transformation/BylineProcessingFieldTransformerFactoryTest.java
+++ b/src/test/java/com/ft/methodearticlemapper/transformation/BylineProcessingFieldTransformerFactoryTest.java
@@ -128,7 +128,7 @@ public class BylineProcessingFieldTransformerFactoryTest {
     }
 
     private void checkTransformation(String originalByline, String expectedTransformedByline) {
-        String actualTransformedByline = bylineTransformer.transform(originalByline, TRANSACTION_ID);
+        String actualTransformedByline = bylineTransformer.transform(originalByline, TRANSACTION_ID, TransformationMode.PUBLISH);
         assertThat(actualTransformedByline, is(equalTo(expectedTransformedByline)));
     }
 

--- a/src/test/java/com/ft/methodearticlemapper/transformation/EomFileProcessorTest.java
+++ b/src/test/java/com/ft/methodearticlemapper/transformation/EomFileProcessorTest.java
@@ -190,10 +190,10 @@ public class EomFileProcessorTest {
     @Before
     public void setUp() throws Exception {
         bodyTransformer = mock(FieldTransformer.class);
-        when(bodyTransformer.transform(anyString(), anyString(), anyVararg())).thenReturn(TRANSFORMED_BODY);
+        when(bodyTransformer.transform(anyString(), anyString(), eq(TransformationMode.PUBLISH), anyVararg())).thenReturn(TRANSFORMED_BODY);
 
         bylineTransformer = mock(FieldTransformer.class);
-        when(bylineTransformer.transform(anyString(), anyString())).thenReturn(TRANSFORMED_BYLINE);
+        when(bylineTransformer.transform(anyString(), anyString(), eq(TransformationMode.PUBLISH))).thenReturn(TRANSFORMED_BYLINE);
 
         htmlFieldProcessor = spy(new Html5SelfClosingTagBodyProcessor());
 
@@ -273,7 +273,7 @@ public class EomFileProcessorTest {
                 .build();
 
         String expectedBody = "<body id=\"some-random-value\"><foo/></body>";
-        when(bodyTransformer.transform(anyString(), anyString(), anyVararg())).thenReturn(expectedBody);
+        when(bodyTransformer.transform(anyString(), anyString(), eq(TransformationMode.PUBLISH), anyVararg())).thenReturn(expectedBody);
 
         final Content expectedContent = Content.builder()
                 .withValuesFrom(standardExpectedContent)
@@ -284,7 +284,7 @@ public class EomFileProcessorTest {
 
         verify(bodyTransformer).transform(
                 anyString(),
-                eq(TRANSACTION_ID),
+                eq(TRANSACTION_ID), eq(TransformationMode.PUBLISH),
                 eq(Maps.immutableEntry("uuid", eomFile.getUuid())),
                 eq(Maps.immutableEntry("apiHost", API_HOST)));
         assertThat(content, equalTo(expectedContent));
@@ -305,7 +305,7 @@ public class EomFileProcessorTest {
                 .build();
 
         String expectedBody = "<body id=\"some-random-value\"><foo/></body>";
-        when(bodyTransformer.transform(anyString(), anyString(), anyVararg())).thenReturn(expectedBody);
+        when(bodyTransformer.transform(anyString(), anyString(), eq(TransformationMode.PUBLISH), anyVararg())).thenReturn(expectedBody);
 
         final Content expectedContent = Content.builder()
                 .withValuesFrom(standardExpectedContent)
@@ -315,7 +315,7 @@ public class EomFileProcessorTest {
 
         verify(bodyTransformer).transform(
                 anyString(),
-                eq(TRANSACTION_ID),
+                eq(TRANSACTION_ID), eq(TransformationMode.PUBLISH),
                 eq(Maps.immutableEntry("uuid", eomFile.getUuid())),
                 eq(Maps.immutableEntry("apiHost", API_HOST)));
         assertThat(content, equalTo(expectedContent));
@@ -358,7 +358,7 @@ public class EomFileProcessorTest {
 
         verify(bodyTransformer).transform(
                 anyString(),
-                eq(TRANSACTION_ID),
+                eq(TRANSACTION_ID), eq(TransformationMode.PUBLISH),
                 eq(Maps.immutableEntry("uuid", eomFile.getUuid())),
                 eq(Maps.immutableEntry("apiHost", API_HOST)));
         assertThat(content, equalTo(expectedContent));
@@ -371,7 +371,7 @@ public class EomFileProcessorTest {
                 .build();
 
         String expectedBody = "<body id=\"some-random-value\"><foo/></body>";
-        when(bodyTransformer.transform(anyString(), anyString(), anyVararg())).thenReturn(expectedBody);
+        when(bodyTransformer.transform(anyString(), anyString(), eq(TransformationMode.PUBLISH), anyVararg())).thenReturn(expectedBody);
 
         final Content expectedContent = Content.builder()
                 .withValuesFrom(standardExpectedContent)
@@ -381,7 +381,7 @@ public class EomFileProcessorTest {
 
         verify(bodyTransformer).transform(
                 anyString(),
-                eq(TRANSACTION_ID),
+                eq(TRANSACTION_ID), eq(TransformationMode.PUBLISH),
                 eq(Maps.immutableEntry("uuid", eomFile.getUuid())),
                 eq(Maps.immutableEntry("apiHost", API_HOST)));
         assertThat(content, equalTo(expectedContent));
@@ -390,42 +390,42 @@ public class EomFileProcessorTest {
     @Test(expected = IllegalArgumentException.class)
     public void shouldThrowExceptionIfBodyTagIsMissingFromTransformedBody() {
         final EomFile eomFile = createEomStoryFile(uuid);
-        when(bodyTransformer.transform(anyString(), anyString(), anyVararg())).thenReturn("<p>some other random text</p>");
+        when(bodyTransformer.transform(anyString(), anyString(), eq(TransformationMode.PUBLISH), anyVararg())).thenReturn("<p>some other random text</p>");
         eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, LAST_MODIFIED);
     }
 
     @Test(expected = UntransformableMethodeContentException.class)
     public void shouldThrowExceptionIfBodyIsNull() {
         final EomFile eomFile = createEomStoryFile(uuid);
-        when(bodyTransformer.transform(anyString(), anyString(), anyVararg())).thenReturn(null);
+        when(bodyTransformer.transform(anyString(), anyString(), eq(TransformationMode.PUBLISH), anyVararg())).thenReturn(null);
         eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, LAST_MODIFIED);
     }
 
     @Test(expected = UntransformableMethodeContentException.class)
     public void shouldThrowExceptionIfBodyIsEmpty() {
         final EomFile eomFile = createEomStoryFile(uuid);
-        when(bodyTransformer.transform(anyString(), anyString(), anyVararg())).thenReturn("");
+        when(bodyTransformer.transform(anyString(), anyString(), eq(TransformationMode.PUBLISH), anyVararg())).thenReturn("");
         eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, LAST_MODIFIED);
     }
 
     @Test(expected = UntransformableMethodeContentException.class)
     public void shouldThrowExceptionIfTransformedBodyIsBlank() {
         final EomFile eomFile = createEomStoryFile(uuid);
-        when(bodyTransformer.transform(anyString(), anyString(), anyVararg())).thenReturn("<body> \n \n \n </body>");
+        when(bodyTransformer.transform(anyString(), anyString(), eq(TransformationMode.PUBLISH), anyVararg())).thenReturn("<body> \n \n \n </body>");
         eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, LAST_MODIFIED);
     }
 
     @Test(expected = UntransformableMethodeContentException.class)
     public void shouldThrowExceptionIfTransformedBodyIsEmpty() {
         final EomFile eomFile = createEomStoryFile(uuid);
-        when(bodyTransformer.transform(anyString(), anyString(), anyVararg())).thenReturn(EMPTY_BODY);
+        when(bodyTransformer.transform(anyString(), anyString(), eq(TransformationMode.PUBLISH), anyVararg())).thenReturn(EMPTY_BODY);
         eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, LAST_MODIFIED);
     }
 
     @Test
     public void thatPreviewEmptyTransformedBodyIsAllowed() {
         final EomFile eomFile = createEomStoryFile(uuid);
-        when(bodyTransformer.transform(anyString(), anyString(), anyVararg())).thenReturn(EMPTY_BODY);
+        when(bodyTransformer.transform(anyString(), anyString(), eq(TransformationMode.PREVIEW), anyVararg())).thenReturn(EMPTY_BODY);
         Content actual = eomFileProcessor.processPreview(eomFile, TRANSACTION_ID, new Date());
         assertThat(actual.getBody(), is(equalTo(EMPTY_BODY)));
     }
@@ -434,7 +434,7 @@ public class EomFileProcessorTest {
     public void thatContentPackageNullBodyIsAllowed() {
         final EomFile eomFile = createEomFileWithRandomContentPackage();
 
-        when(bodyTransformer.transform(anyString(), anyString(), anyVararg())).thenReturn(null);
+        when(bodyTransformer.transform(anyString(), anyString(), eq(TransformationMode.PUBLISH), anyVararg())).thenReturn(null);
         Content actual = eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, new Date());
         assertThat(actual.getBody(), is(equalTo(EMPTY_BODY)));
     }
@@ -443,7 +443,7 @@ public class EomFileProcessorTest {
     public void thatContentPackageEmptyBodyIsAllowed() {
         final EomFile eomFile = createEomFileWithRandomContentPackage();
 
-        when(bodyTransformer.transform(anyString(), anyString(), anyVararg())).thenReturn("");
+        when(bodyTransformer.transform(anyString(), anyString(), eq(TransformationMode.PUBLISH), anyVararg())).thenReturn("");
         Content actual = eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, new Date());
         assertThat(actual.getBody(), is(equalTo(EMPTY_BODY)));
     }
@@ -452,7 +452,7 @@ public class EomFileProcessorTest {
     public void thatContentPackageBlankTransformedBodyIsAllowed() {
         final EomFile eomFile = createEomFileWithRandomContentPackage();
 
-        when(bodyTransformer.transform(anyString(), anyString(), anyVararg())).thenReturn("<body> \n \n \n </body>");
+        when(bodyTransformer.transform(anyString(), anyString(), eq(TransformationMode.PUBLISH), anyVararg())).thenReturn("<body> \n \n \n </body>");
         Content actual = eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, new Date());
         assertThat(actual.getBody(), is(equalTo(EMPTY_BODY)));
     }
@@ -503,7 +503,7 @@ public class EomFileProcessorTest {
 
         Content content = eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, LAST_MODIFIED);
 
-        verify(bylineTransformer).transform("<byline>" + byline + "</byline>", TRANSACTION_ID);
+        verify(bylineTransformer).transform("<byline>" + byline + "</byline>", TRANSACTION_ID, TransformationMode.PUBLISH);
         assertThat(content, equalTo(expectedContent));
     }
 
@@ -567,7 +567,7 @@ public class EomFileProcessorTest {
 
     @Test
     public void testMainImageReferenceIsNotPutInBodyWhenMissing() throws Exception {
-        when(bodyTransformer.transform(anyString(), anyString(), anyVararg())).then(returnsFirstArg());
+        when(bodyTransformer.transform(anyString(), anyString(), eq(TransformationMode.PUBLISH), anyVararg())).then(returnsFirstArg());
         final EomFile eomFile = createStandardEomFile(uuid);
 
         Content content = eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, LAST_MODIFIED);
@@ -995,6 +995,8 @@ public class EomFileProcessorTest {
 
     @Test
     public void testAgencyContentProcessPreview() {
+        when(bodyTransformer.transform(anyString(), anyString(), eq(TransformationMode.PREVIEW), anyVararg())).thenReturn(TRANSFORMED_BODY);
+        
         final EomFile eomFile = createStandardEomFileAgencySource(uuid);
         Content content = eomFileProcessor.processPreview(eomFile, TRANSACTION_ID, LAST_MODIFIED);
 
@@ -1018,7 +1020,7 @@ public class EomFileProcessorTest {
             + "<p>random text for now</p>"
             + "<ft-content type=\"http://www.ft.com/ontology/content/ImageSet\" url=\"http://api.ft.com/content/" + expectedUUID + "\" data-embedded=\"true\"></ft-content>"
             + "</body>";
-        when(bodyTransformer.transform(anyString(), anyString(), anyVararg())).thenReturn(expectedBody);
+        when(bodyTransformer.transform(anyString(), anyString(), eq(TransformationMode.PUBLISH), anyVararg())).thenReturn(expectedBody);
 
         EomFile eomFile = createStandardEomFileWithImageSet(IMAGE_SET_UUID);
         Content content = eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, LAST_MODIFIED);
@@ -1033,7 +1035,7 @@ public class EomFileProcessorTest {
             + "<p>random text for now</p>"
             + "<ft-content type=\"http://www.ft.com/ontology/content/ImageSet\" url=\"http://api.ft.com/content/" + expectedUUID + "\" data-embedded=\"true\"></ft-content>"
             + "</body>";
-        when(bodyTransformer.transform(anyString(), anyString(), anyVararg())).thenReturn(expectedBody);
+        when(bodyTransformer.transform(anyString(), anyString(), eq(TransformationMode.PREVIEW), anyVararg())).thenReturn(expectedBody);
 
         EomFile eomFile = createStandardEomFileWithImageSet(IMAGE_SET_UUID);
         Content content = eomFileProcessor.processPreview(eomFile, TRANSACTION_ID, LAST_MODIFIED);
@@ -1081,7 +1083,7 @@ public class EomFileProcessorTest {
     }
 
     private void testMainImageReferenceIsPutInBodyWithMetadataFlag(String articleImageMetadataFlag, String expectedTransformedBody) {
-        when(bodyTransformer.transform(anyString(), anyString(), anyVararg())).then(returnsFirstArg());
+        when(bodyTransformer.transform(anyString(), anyString(), eq(TransformationMode.PUBLISH), anyVararg())).then(returnsFirstArg());
         final UUID imageUuid = UUID.randomUUID();
         final UUID expectedMainImageUuid = DeriveUUID.with(DeriveUUID.Salts.IMAGE_SET).from(imageUuid);
         final EomFile eomFile = createStandardEomFileWithMainImage(uuid, imageUuid,

--- a/src/test/java/com/ft/methodearticlemapper/transformation/EomFileProcessorTest.java
+++ b/src/test/java/com/ft/methodearticlemapper/transformation/EomFileProcessorTest.java
@@ -212,7 +212,7 @@ public class EomFileProcessorTest {
         final EomFile eomFile = new EomFile.Builder()
                 .withValuesFrom(createStandardEomFile(uuid, TRUE))
                 .build();
-        eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, new Date());
+        eomFileProcessor.process(eomFile, TransformationMode.PUBLISH, TRANSACTION_ID, new Date());
     }
 
     @Test(expected = EmbargoDateInTheFutureException.class)
@@ -220,7 +220,7 @@ public class EomFileProcessorTest {
         final EomFile eomFile = new EomFile.Builder()
                 .withValuesFrom(createStandardEomFileWithEmbargoDateInTheFuture(uuid))
                 .build();
-        eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, LAST_MODIFIED);
+        eomFileProcessor.process(eomFile, TransformationMode.PUBLISH, TRANSACTION_ID, LAST_MODIFIED);
     }
 
     @Test(expected = UnsupportedObjectTypeException.class)
@@ -228,7 +228,7 @@ public class EomFileProcessorTest {
         final EomFile eomFile = new EomFile.Builder()
                 .withValuesFrom(createStandardEomFileWithObjectLocation(uuid, ""))
                 .build();
-        eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, new Date());
+        eomFileProcessor.process(eomFile, TransformationMode.PUBLISH, TRANSACTION_ID, new Date());
     }
 
     @Test(expected = UnsupportedObjectTypeException.class)
@@ -237,7 +237,7 @@ public class EomFileProcessorTest {
         final EomFile eomFile = new EomFile.Builder()
                 .withValuesFrom(createStandardEomFileWithObjectLocation(uuid, objectLocation))
                 .build();
-        eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, new Date());
+        eomFileProcessor.process(eomFile, TransformationMode.PUBLISH, TRANSACTION_ID, new Date());
     }
 
     @Test(expected = NotWebChannelException.class)
@@ -246,7 +246,7 @@ public class EomFileProcessorTest {
                 .withValuesFrom(createStandardEomFile(uuid))
                 .withSystemAttributes(buildEomFileSystemAttributes("NotFTcom"))
                 .build();
-        eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, LAST_MODIFIED);
+        eomFileProcessor.process(eomFile, TransformationMode.PUBLISH, TRANSACTION_ID, LAST_MODIFIED);
     }
 
     @Test(expected = SourceNotEligibleForPublishException.class)
@@ -254,7 +254,7 @@ public class EomFileProcessorTest {
         final EomFile eomFile = new EomFile.Builder()
                 .withValuesFrom(createStandardEomFileNonFtOrAgencySource(uuid))
                 .build();
-        eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, LAST_MODIFIED);
+        eomFileProcessor.process(eomFile, TransformationMode.PUBLISH, TRANSACTION_ID, LAST_MODIFIED);
     }
 
     @Test(expected = WorkflowStatusNotEligibleForPublishException.class)
@@ -263,7 +263,7 @@ public class EomFileProcessorTest {
                 .withValuesFrom(createStandardEomFile(uuid))
                 .withWorkflowStatus("Stories/Edit")
                 .build();
-        eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, LAST_MODIFIED);
+        eomFileProcessor.process(eomFile, TransformationMode.PUBLISH, TRANSACTION_ID, LAST_MODIFIED);
     }
 
     @Test
@@ -280,7 +280,7 @@ public class EomFileProcessorTest {
                 .withFirstPublishedDate(toDate(initialPublicationDateAsStringPreWfsEnforce, DATE_TIME_FORMAT))
                 .withXmlBody(expectedBody).build();
 
-        Content content = eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, LAST_MODIFIED);
+        Content content = eomFileProcessor.process(eomFile, TransformationMode.PUBLISH, TRANSACTION_ID, LAST_MODIFIED);
 
         verify(bodyTransformer).transform(
                 anyString(),
@@ -295,7 +295,7 @@ public class EomFileProcessorTest {
         final EomFile eomFile = new EomFile.Builder()
                 .withValuesFrom(createEomStoryFile(uuid, "FTContentMove/Ready", "FTcom", initialPublicationDateAsString))
                 .build();
-        eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, LAST_MODIFIED);
+        eomFileProcessor.process(eomFile, TransformationMode.PUBLISH, TRANSACTION_ID, LAST_MODIFIED);
     }
 
     @Test
@@ -311,7 +311,7 @@ public class EomFileProcessorTest {
                 .withValuesFrom(standardExpectedContent)
                 .withXmlBody(expectedBody).build();
 
-        Content content = eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, LAST_MODIFIED);
+        Content content = eomFileProcessor.process(eomFile, TransformationMode.PUBLISH, TRANSACTION_ID, LAST_MODIFIED);
 
         verify(bodyTransformer).transform(
                 anyString(),
@@ -326,7 +326,7 @@ public class EomFileProcessorTest {
         final EomFile eomFile = new EomFile.Builder()
                 .withValuesFrom(createDwcComponentFile(uuid))
                 .build();
-        eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, LAST_MODIFIED);
+        eomFileProcessor.process(eomFile, TransformationMode.PUBLISH, TRANSACTION_ID, LAST_MODIFIED);
     }
 
     @Test(expected = MethodeMissingFieldException.class)
@@ -334,12 +334,12 @@ public class EomFileProcessorTest {
         final EomFile eomFile = new EomFile.Builder()
                 .withValuesFrom(createStandardEomFileWithNoLastPublicationDate(uuid))
                 .build();
-        eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, LAST_MODIFIED);
+        eomFileProcessor.process(eomFile, TransformationMode.PUBLISH, TRANSACTION_ID, LAST_MODIFIED);
     }
 
     @Test
     public void shouldNotBarfOnExternalDtd() {
-        Content content = eomFileProcessor.processPublication(standardEomFile, TRANSACTION_ID, LAST_MODIFIED);
+        Content content = eomFileProcessor.process(standardEomFile, TransformationMode.PUBLISH, TRANSACTION_ID, LAST_MODIFIED);
         Content expectedContent = createStandardExpectedFtContent();
         assertThat(content, equalTo(expectedContent));
     }
@@ -354,7 +354,7 @@ public class EomFileProcessorTest {
                 .withValuesFrom(standardExpectedContent)
                 .withXmlBody(TRANSFORMED_BODY).build();
 
-        Content content = eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, LAST_MODIFIED);
+        Content content = eomFileProcessor.process(eomFile, TransformationMode.PUBLISH, TRANSACTION_ID, LAST_MODIFIED);
 
         verify(bodyTransformer).transform(
                 anyString(),
@@ -377,7 +377,7 @@ public class EomFileProcessorTest {
                 .withValuesFrom(standardExpectedContent)
                 .withXmlBody(expectedBody).build();
 
-        Content content = eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, LAST_MODIFIED);
+        Content content = eomFileProcessor.process(eomFile, TransformationMode.PUBLISH, TRANSACTION_ID, LAST_MODIFIED);
 
         verify(bodyTransformer).transform(
                 anyString(),
@@ -391,42 +391,42 @@ public class EomFileProcessorTest {
     public void shouldThrowExceptionIfBodyTagIsMissingFromTransformedBody() {
         final EomFile eomFile = createEomStoryFile(uuid);
         when(bodyTransformer.transform(anyString(), anyString(), eq(TransformationMode.PUBLISH), anyVararg())).thenReturn("<p>some other random text</p>");
-        eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, LAST_MODIFIED);
+        eomFileProcessor.process(eomFile, TransformationMode.PUBLISH, TRANSACTION_ID, LAST_MODIFIED);
     }
 
     @Test(expected = UntransformableMethodeContentException.class)
     public void shouldThrowExceptionIfBodyIsNull() {
         final EomFile eomFile = createEomStoryFile(uuid);
         when(bodyTransformer.transform(anyString(), anyString(), eq(TransformationMode.PUBLISH), anyVararg())).thenReturn(null);
-        eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, LAST_MODIFIED);
+        eomFileProcessor.process(eomFile, TransformationMode.PUBLISH, TRANSACTION_ID, LAST_MODIFIED);
     }
 
     @Test(expected = UntransformableMethodeContentException.class)
     public void shouldThrowExceptionIfBodyIsEmpty() {
         final EomFile eomFile = createEomStoryFile(uuid);
         when(bodyTransformer.transform(anyString(), anyString(), eq(TransformationMode.PUBLISH), anyVararg())).thenReturn("");
-        eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, LAST_MODIFIED);
+        eomFileProcessor.process(eomFile, TransformationMode.PUBLISH, TRANSACTION_ID, LAST_MODIFIED);
     }
 
     @Test(expected = UntransformableMethodeContentException.class)
     public void shouldThrowExceptionIfTransformedBodyIsBlank() {
         final EomFile eomFile = createEomStoryFile(uuid);
         when(bodyTransformer.transform(anyString(), anyString(), eq(TransformationMode.PUBLISH), anyVararg())).thenReturn("<body> \n \n \n </body>");
-        eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, LAST_MODIFIED);
+        eomFileProcessor.process(eomFile, TransformationMode.PUBLISH, TRANSACTION_ID, LAST_MODIFIED);
     }
 
     @Test(expected = UntransformableMethodeContentException.class)
     public void shouldThrowExceptionIfTransformedBodyIsEmpty() {
         final EomFile eomFile = createEomStoryFile(uuid);
         when(bodyTransformer.transform(anyString(), anyString(), eq(TransformationMode.PUBLISH), anyVararg())).thenReturn(EMPTY_BODY);
-        eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, LAST_MODIFIED);
+        eomFileProcessor.process(eomFile, TransformationMode.PUBLISH, TRANSACTION_ID, LAST_MODIFIED);
     }
 
     @Test
     public void thatPreviewEmptyTransformedBodyIsAllowed() {
         final EomFile eomFile = createEomStoryFile(uuid);
         when(bodyTransformer.transform(anyString(), anyString(), eq(TransformationMode.PREVIEW), anyVararg())).thenReturn(EMPTY_BODY);
-        Content actual = eomFileProcessor.processPreview(eomFile, TRANSACTION_ID, new Date());
+        Content actual = eomFileProcessor.process(eomFile, TransformationMode.PREVIEW, TRANSACTION_ID, new Date());
         assertThat(actual.getBody(), is(equalTo(EMPTY_BODY)));
     }
 
@@ -435,7 +435,7 @@ public class EomFileProcessorTest {
         final EomFile eomFile = createEomFileWithRandomContentPackage();
 
         when(bodyTransformer.transform(anyString(), anyString(), eq(TransformationMode.PUBLISH), anyVararg())).thenReturn(null);
-        Content actual = eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, new Date());
+        Content actual = eomFileProcessor.process(eomFile, TransformationMode.PUBLISH, TRANSACTION_ID, new Date());
         assertThat(actual.getBody(), is(equalTo(EMPTY_BODY)));
     }
 
@@ -444,7 +444,7 @@ public class EomFileProcessorTest {
         final EomFile eomFile = createEomFileWithRandomContentPackage();
 
         when(bodyTransformer.transform(anyString(), anyString(), eq(TransformationMode.PUBLISH), anyVararg())).thenReturn("");
-        Content actual = eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, new Date());
+        Content actual = eomFileProcessor.process(eomFile, TransformationMode.PUBLISH, TRANSACTION_ID, new Date());
         assertThat(actual.getBody(), is(equalTo(EMPTY_BODY)));
     }
 
@@ -453,7 +453,7 @@ public class EomFileProcessorTest {
         final EomFile eomFile = createEomFileWithRandomContentPackage();
 
         when(bodyTransformer.transform(anyString(), anyString(), eq(TransformationMode.PUBLISH), anyVararg())).thenReturn("<body> \n \n \n </body>");
-        Content actual = eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, new Date());
+        Content actual = eomFileProcessor.process(eomFile, TransformationMode.PUBLISH, TRANSACTION_ID, new Date());
         assertThat(actual.getBody(), is(equalTo(EMPTY_BODY)));
     }
 
@@ -479,7 +479,7 @@ public class EomFileProcessorTest {
                 .withPublishReference(reference)
                 .withXmlBody(TRANSFORMED_BODY).build();
 
-        Content content = eomFileProcessor.processPublication(eomFile, reference, LAST_MODIFIED);
+        Content content = eomFileProcessor.process(eomFile, TransformationMode.PUBLISH, reference, LAST_MODIFIED);
 
         assertThat(content, equalTo(expectedContent));
     }
@@ -501,7 +501,7 @@ public class EomFileProcessorTest {
                 .withIdentifiers(ImmutableSortedSet.of(new Identifier(METHODE, uuid.toString())))
                 .withByline(TRANSFORMED_BYLINE).build();
 
-        Content content = eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, LAST_MODIFIED);
+        Content content = eomFileProcessor.process(eomFile, TransformationMode.PUBLISH, TRANSACTION_ID, LAST_MODIFIED);
 
         verify(bylineTransformer).transform("<byline>" + byline + "</byline>", TRANSACTION_ID, TransformationMode.PUBLISH);
         assertThat(content, equalTo(expectedContent));
@@ -518,7 +518,7 @@ public class EomFileProcessorTest {
         expectedException.expect(MethodeContentNotEligibleForPublishException.class);
         expectedException.expect(hasProperty("message", equalTo("[EOM::SomethingElse] not an EOM::CompoundStory.")));
 
-        eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, LAST_MODIFIED);
+        eomFileProcessor.process(eomFile, TransformationMode.PUBLISH, TRANSACTION_ID, LAST_MODIFIED);
     }
 
     @Test
@@ -527,7 +527,7 @@ public class EomFileProcessorTest {
         final UUID expectedMainImageUuid = DeriveUUID.with(DeriveUUID.Salts.IMAGE_SET).from(imageUuid);
         final EomFile eomFile = createStandardEomFileWithMainImage(uuid, imageUuid, "Primary size");
 
-        Content content = eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, LAST_MODIFIED);
+        Content content = eomFileProcessor.process(eomFile, TransformationMode.PUBLISH, TRANSACTION_ID, LAST_MODIFIED);
         assertThat(content.getMainImage(), equalTo(expectedMainImageUuid.toString()));
     }
 
@@ -535,7 +535,7 @@ public class EomFileProcessorTest {
     public void testMainImageIsNullIfMissing() throws Exception {
         final EomFile eomFile = createStandardEomFile(uuid);
 
-        Content content = eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, LAST_MODIFIED);
+        Content content = eomFileProcessor.process(eomFile, TransformationMode.PUBLISH, TRANSACTION_ID, LAST_MODIFIED);
         assertThat(content.getMainImage(), nullValue());
     }
 
@@ -570,7 +570,7 @@ public class EomFileProcessorTest {
         when(bodyTransformer.transform(anyString(), anyString(), eq(TransformationMode.PUBLISH), anyVararg())).then(returnsFirstArg());
         final EomFile eomFile = createStandardEomFile(uuid);
 
-        Content content = eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, LAST_MODIFIED);
+        Content content = eomFileProcessor.process(eomFile, TransformationMode.PUBLISH, TRANSACTION_ID, LAST_MODIFIED);
 
         String expectedBody = "<body>" +
                 "                <p>random text for now</p>" +
@@ -583,7 +583,7 @@ public class EomFileProcessorTest {
     public void testStoryPackage() {
         final UUID storyPackageUuid = UUID.randomUUID();
         final EomFile eomFile = createStandardEomFileWithStoryPackage(uuid, storyPackageUuid.toString());
-        Content content = eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, LAST_MODIFIED);
+        Content content = eomFileProcessor.process(eomFile, TransformationMode.PUBLISH, TRANSACTION_ID, LAST_MODIFIED);
 
         assertThat(content.getStoryPackage(), notNullValue());
         assertThat(content.getStoryPackage(), equalTo(storyPackageUuid.toString()));
@@ -593,7 +593,7 @@ public class EomFileProcessorTest {
     public void testStoryPackageWithInvalidUuid() {
         final String storyPackageUuid = "invalid-uuid";
         final EomFile eomFile = createStandardEomFileWithStoryPackage(uuid, storyPackageUuid);
-        eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, LAST_MODIFIED);
+        eomFileProcessor.process(eomFile, TransformationMode.PUBLISH, TRANSACTION_ID, LAST_MODIFIED);
     }
 
     private static EomFile createStandardEomFileWithStoryPackage(UUID uuid, String storyPackageUuid) {
@@ -631,7 +631,7 @@ public class EomFileProcessorTest {
     public void testCommentsArePresent() {
         final EomFile eomFile = createStandardEomFile(uuid);
 
-        Content content = eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, LAST_MODIFIED);
+        Content content = eomFileProcessor.process(eomFile, TransformationMode.PUBLISH, TRANSACTION_ID, LAST_MODIFIED);
 
         assertThat(content.getComments(), notNullValue());
         assertThat(content.getComments().isEnabled(), is(true));
@@ -641,7 +641,7 @@ public class EomFileProcessorTest {
     public void testStandoutFieldsArePresent() {
         final EomFile eomFile = createStandardEomFile(uuid);
 
-        Content content = eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, LAST_MODIFIED);
+        Content content = eomFileProcessor.process(eomFile, TransformationMode.PUBLISH, TRANSACTION_ID, LAST_MODIFIED);
         assertThat(content.getStandout().isEditorsChoice(), is(true));
         assertThat(content.getStandout().isExclusive(), is(true));
         assertThat(content.getStandout().isScoop(), is(true));
@@ -657,7 +657,7 @@ public class EomFileProcessorTest {
                 .withValue(value.getBytes(UTF_8))
                 .build();
 
-        eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, LAST_MODIFIED);
+        eomFileProcessor.process(eomFile, TransformationMode.PUBLISH, TRANSACTION_ID, LAST_MODIFIED);
     }
 
     @Test
@@ -665,7 +665,7 @@ public class EomFileProcessorTest {
         final EomFile eomFile = createStandardEomFileWithContributorRights(
                 uuid, ContributorRights.ALL_NO_PAYMENT.getValue());
 
-        Content content = eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, LAST_MODIFIED);
+        Content content = eomFileProcessor.process(eomFile, TransformationMode.PUBLISH, TRANSACTION_ID, LAST_MODIFIED);
         assertThat(content.getCanBeSyndicated(), is(Syndication.YES));
     }
 
@@ -680,7 +680,7 @@ public class EomFileProcessorTest {
             final EomFile eomFileContractContributorRights = createStandardEomFileWithContributorRights(
                     uuid, contributorRight);
 
-            Content content = eomFileProcessor.processPublication(eomFileContractContributorRights, TRANSACTION_ID, LAST_MODIFIED);
+            Content content = eomFileProcessor.process(eomFileContractContributorRights, TransformationMode.PUBLISH, TRANSACTION_ID, LAST_MODIFIED);
             assertThat(content.getCanBeSyndicated(), is(Syndication.WITH_CONTRIBUTOR_PAYMENT));
         }
     }
@@ -690,7 +690,7 @@ public class EomFileProcessorTest {
         final EomFile eomFile = createStandardEomFileWithContributorRights(
                 uuid, ContributorRights.NO_RIGHTS.getValue());
 
-        Content content = eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, LAST_MODIFIED);
+        Content content = eomFileProcessor.process(eomFile, TransformationMode.PUBLISH, TRANSACTION_ID, LAST_MODIFIED);
         assertThat(content.getCanBeSyndicated(), is(Syndication.NO));
     }
 
@@ -708,7 +708,7 @@ public class EomFileProcessorTest {
             final EomFile eomFileContractContributorRights = createStandardEomFileWithContributorRights(
                     uuid, contributorRight);
 
-            Content content = eomFileProcessor.processPublication(eomFileContractContributorRights, TRANSACTION_ID, LAST_MODIFIED);
+            Content content = eomFileProcessor.process(eomFileContractContributorRights, TransformationMode.PUBLISH, TRANSACTION_ID, LAST_MODIFIED);
             assertThat("contributorRight=" + contributorRight, content.getCanBeSyndicated(), is(Syndication.VERIFY));
         }
     }
@@ -738,7 +738,7 @@ public class EomFileProcessorTest {
                 .withWorkflowStatus(EomFile.WEB_READY)
                 .build();
 
-        Content content = eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, LAST_MODIFIED);
+        Content content = eomFileProcessor.process(eomFile, TransformationMode.PUBLISH, TRANSACTION_ID, LAST_MODIFIED);
         assertThat(content.getCanBeSyndicated(), is(Syndication.VERIFY));
     }
 
@@ -747,7 +747,7 @@ public class EomFileProcessorTest {
         final EomFile eomFile = createStandardEomFileWithSubscriptionLevel(uuid, "");
         expectedException.expect(UntransformableMethodeContentException.class);
 
-        Content content = eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, LAST_MODIFIED);
+        Content content = eomFileProcessor.process(eomFile, TransformationMode.PUBLISH, TRANSACTION_ID, LAST_MODIFIED);
         assertNull(content.getAccessLevel());
     }
 
@@ -756,14 +756,14 @@ public class EomFileProcessorTest {
         final EomFile eomFile = createStandardEomFileWithSubscriptionLevel(uuid, "5");
         expectedException.expect(UntransformableMethodeContentException.class);
 
-        Content content = eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, LAST_MODIFIED);
+        Content content = eomFileProcessor.process(eomFile, TransformationMode.PUBLISH, TRANSACTION_ID, LAST_MODIFIED);
         assertNull(content.getAccessLevel());
     }
 
     @Test
     public void testArticleHasSubscribedAccessLevel() {
         final EomFile eomFile = createStandardEomFileWithSubscriptionLevel(uuid, Integer.toString(FOLLOW_USUAL_RULES.getSubscriptionLevel()));
-        Content content = eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, LAST_MODIFIED);
+        Content content = eomFileProcessor.process(eomFile, TransformationMode.PUBLISH, TRANSACTION_ID, LAST_MODIFIED);
         assertThat(content.getAccessLevel(), is(AccessLevel.SUBSCRIBED));
     }
 
@@ -771,7 +771,7 @@ public class EomFileProcessorTest {
     public void testArticleHasFreeAccessLevel() {
         final EomFile eomFile = createStandardEomFileWithSubscriptionLevel(uuid, Integer.toString(SHOWCASE.getSubscriptionLevel()));
 
-        Content content = eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, LAST_MODIFIED);
+        Content content = eomFileProcessor.process(eomFile, TransformationMode.PUBLISH, TRANSACTION_ID, LAST_MODIFIED);
         assertThat(content.getAccessLevel(), is(AccessLevel.FREE));
     }
 
@@ -779,7 +779,7 @@ public class EomFileProcessorTest {
     public void testArticleHasPremiumAccessLevel() {
         final EomFile eomFile = createStandardEomFileWithSubscriptionLevel(uuid, Integer.toString(PREMIUM.getSubscriptionLevel()));
 
-        Content content = eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, LAST_MODIFIED);
+        Content content = eomFileProcessor.process(eomFile, TransformationMode.PUBLISH, TRANSACTION_ID, LAST_MODIFIED);
         assertThat(content.getAccessLevel(), is(AccessLevel.PREMIUM));
     }
 
@@ -791,7 +791,7 @@ public class EomFileProcessorTest {
     @Test
     public void thatStoryTypeIsAValidType() {
         final EomFile eomFile = createEomStoryFile(uuid);
-        Content content = eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, LAST_MODIFIED);
+        Content content = eomFileProcessor.process(eomFile, TransformationMode.PUBLISH, TRANSACTION_ID, LAST_MODIFIED);
         assertThat(content, notNullValue());
     }
 
@@ -807,7 +807,7 @@ public class EomFileProcessorTest {
           .withValue(buildEomFileValue(templateValues))
           .build();
 
-        Content content = eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, LAST_MODIFIED);
+        Content content = eomFileProcessor.process(eomFile, TransformationMode.PUBLISH, TRANSACTION_ID, LAST_MODIFIED);
         assertThat(content.getStandfirst(), is(equalToIgnoringWhiteSpace(expectedStandfirst)));
     }
 
@@ -821,7 +821,7 @@ public class EomFileProcessorTest {
           .withValue(buildEomFileValue(templateValues))
           .build();
 
-        Content content = eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, LAST_MODIFIED);
+        Content content = eomFileProcessor.process(eomFile, TransformationMode.PUBLISH, TRANSACTION_ID, LAST_MODIFIED);
         assertThat(content.getStandfirst(), is(nullValue()));
     }
 
@@ -829,7 +829,7 @@ public class EomFileProcessorTest {
     public void thatStandfirstIsOptional() {
         final EomFile eomFile = createStandardEomFile(uuid);
 
-        Content content = eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, LAST_MODIFIED);
+        Content content = eomFileProcessor.process(eomFile, TransformationMode.PUBLISH, TRANSACTION_ID, LAST_MODIFIED);
         assertThat(content.getStandfirst(), is(nullValue()));
     }
 
@@ -847,7 +847,7 @@ public class EomFileProcessorTest {
           .withValue(buildEomFileValue(templateValues))
           .build();
 
-        final Content content = eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, LAST_MODIFIED);
+        final Content content = eomFileProcessor.process(eomFile, TransformationMode.PUBLISH, TRANSACTION_ID, LAST_MODIFIED);
         assertThat(content, is(notNullValue()));
 
         final AlternativeTitles actual = content.getAlternativeTitles();
@@ -860,7 +860,7 @@ public class EomFileProcessorTest {
     public void thatAlternativeTitlesAreOptional() {
         final EomFile eomFile = createStandardEomFile(uuid);
 
-        final Content content = eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, LAST_MODIFIED);
+        final Content content = eomFileProcessor.process(eomFile, TransformationMode.PUBLISH, TRANSACTION_ID, LAST_MODIFIED);
         assertThat(content, is(notNullValue()));
 
         final AlternativeTitles actual = content.getAlternativeTitles();
@@ -880,7 +880,7 @@ public class EomFileProcessorTest {
           .withValue(buildEomFileValue(templateValues))
           .build();
 
-        final Content content = eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, LAST_MODIFIED);
+        final Content content = eomFileProcessor.process(eomFile, TransformationMode.PUBLISH, TRANSACTION_ID, LAST_MODIFIED);
         assertThat(content, is(notNullValue()));
 
         final AlternativeTitles actual = content.getAlternativeTitles();
@@ -900,7 +900,7 @@ public class EomFileProcessorTest {
           .withValue(buildEomFileValue(templateValues))
           .build();
 
-        final Content content = eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, LAST_MODIFIED);
+        final Content content = eomFileProcessor.process(eomFile, TransformationMode.PUBLISH, TRANSACTION_ID, LAST_MODIFIED);
         assertThat(content, is(notNullValue()));
 
         final AlternativeTitles actual = content.getAlternativeTitles();
@@ -914,7 +914,7 @@ public class EomFileProcessorTest {
         URI webUrl = URI.create("http://www.ft.com/a-fancy-url");
         final EomFile eomFile = createStandardEomFileWithWebUrl(uuid, webUrl);
 
-        Content content = eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, LAST_MODIFIED);
+        Content content = eomFileProcessor.process(eomFile, TransformationMode.PUBLISH, TRANSACTION_ID, LAST_MODIFIED);
         assertThat(content.getWebUrl(), is(equalTo(webUrl)));
     }
 
@@ -986,7 +986,7 @@ public class EomFileProcessorTest {
     @Test
     public void testAgencyContentProcessPublication() {
         final EomFile eomFile = createStandardEomFileAgencySource(uuid);
-        Content content = eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, LAST_MODIFIED);
+        Content content = eomFileProcessor.process(eomFile, TransformationMode.PUBLISH, TRANSACTION_ID, LAST_MODIFIED);
 
         final Content expectedContent = createStandardExpectedAgencyContent();
 
@@ -998,7 +998,7 @@ public class EomFileProcessorTest {
         when(bodyTransformer.transform(anyString(), anyString(), eq(TransformationMode.PREVIEW), anyVararg())).thenReturn(TRANSFORMED_BODY);
         
         final EomFile eomFile = createStandardEomFileAgencySource(uuid);
-        Content content = eomFileProcessor.processPreview(eomFile, TRANSACTION_ID, LAST_MODIFIED);
+        Content content = eomFileProcessor.process(eomFile, TransformationMode.PREVIEW, TRANSACTION_ID, LAST_MODIFIED);
 
         final Content expectedContent = createStandardExpectedAgencyContent();
 
@@ -1008,7 +1008,7 @@ public class EomFileProcessorTest {
     @Test
     public void testTypeArticleIsDefaultSetIfNoContentPackage() {
         final EomFile eomFile = createStandardEomFile(uuid);
-        Content content = eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, LAST_MODIFIED);
+        Content content = eomFileProcessor.process(eomFile, TransformationMode.PUBLISH, TRANSACTION_ID, LAST_MODIFIED);
 
         assertThat(EomFileProcessor.Type.ARTICLE, equalTo(content.getType()));
     }
@@ -1023,7 +1023,7 @@ public class EomFileProcessorTest {
         when(bodyTransformer.transform(anyString(), anyString(), eq(TransformationMode.PUBLISH), anyVararg())).thenReturn(expectedBody);
 
         EomFile eomFile = createStandardEomFileWithImageSet(IMAGE_SET_UUID);
-        Content content = eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, LAST_MODIFIED);
+        Content content = eomFileProcessor.process(eomFile, TransformationMode.PUBLISH, TRANSACTION_ID, LAST_MODIFIED);
 
         assertThat(content.getBody(), equalToIgnoringWhiteSpace(expectedBody));
     }
@@ -1038,7 +1038,7 @@ public class EomFileProcessorTest {
         when(bodyTransformer.transform(anyString(), anyString(), eq(TransformationMode.PREVIEW), anyVararg())).thenReturn(expectedBody);
 
         EomFile eomFile = createStandardEomFileWithImageSet(IMAGE_SET_UUID);
-        Content content = eomFileProcessor.processPreview(eomFile, TRANSACTION_ID, LAST_MODIFIED);
+        Content content = eomFileProcessor.process(eomFile, TransformationMode.PREVIEW, TRANSACTION_ID, LAST_MODIFIED);
 
         assertThat(content.getBody(), equalToIgnoringWhiteSpace(expectedBody));
     }
@@ -1055,7 +1055,7 @@ public class EomFileProcessorTest {
                 .withValue(buildEomFileValue(templateValues))
                 .build();
 
-        Content content = eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, LAST_MODIFIED);
+        Content content = eomFileProcessor.process(eomFile, TransformationMode.PUBLISH, TRANSACTION_ID, LAST_MODIFIED);
         assertThat(content.getAlternativeStandfirsts().getPromotionalStandfirst(), is(equalToIgnoringWhiteSpace(expectedPromotionalStandfirst)));
     }
 
@@ -1065,8 +1065,30 @@ public class EomFileProcessorTest {
                 .withValuesFrom(createStandardEomFile(uuid))
                 .build();
 
-        Content content = eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, LAST_MODIFIED);
+        Content content = eomFileProcessor.process(eomFile, TransformationMode.PUBLISH, TRANSACTION_ID, LAST_MODIFIED);
         assertThat(content.getAlternativeStandfirsts().getPromotionalStandfirst(), is(nullValue()));
+    }
+
+    @Test
+    public void thatSuggestModeIsPassedThrough() {
+        when(bodyTransformer.transform(anyString(), anyString(), eq(TransformationMode.SUGGEST), anyVararg())).thenReturn(TRANSFORMED_BODY);
+        
+        final EomFile eomFile = new EomFile.Builder()
+                .withValuesFrom(standardEomFile)
+                .build();
+
+        final Content expectedContent = Content.builder()
+                .withValuesFrom(standardExpectedContent)
+                .withXmlBody(TRANSFORMED_BODY).build();
+
+        Content content = eomFileProcessor.process(eomFile, TransformationMode.SUGGEST, TRANSACTION_ID, LAST_MODIFIED);
+
+        verify(bodyTransformer).transform(
+                anyString(),
+                eq(TRANSACTION_ID), eq(TransformationMode.SUGGEST),
+                eq(Maps.immutableEntry("uuid", eomFile.getUuid())),
+                eq(Maps.immutableEntry("apiHost", API_HOST)));
+        assertThat(content, equalTo(expectedContent));
     }
 
     private void testContentPackage(final String description,
@@ -1074,7 +1096,7 @@ public class EomFileProcessorTest {
                                     final String expectedDescription,
                                     final String expectedListId) {
         final EomFile eomFile = createStandardEomFileWithContentPackage(UUID.randomUUID(), true, description, listHref);
-        final Content content = eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, LAST_MODIFIED);
+        final Content content = eomFileProcessor.process(eomFile, TransformationMode.PUBLISH, TRANSACTION_ID, LAST_MODIFIED);
 
         assertThat(content.getType(), is(EomFileProcessor.Type.CONTENT_PACKAGE));
         assertThat(content.getDescription(), is(expectedDescription));
@@ -1089,7 +1111,7 @@ public class EomFileProcessorTest {
         final EomFile eomFile = createStandardEomFileWithMainImage(uuid, imageUuid,
             articleImageMetadataFlag);
         Content content = eomFileProcessor
-            .processPublication(eomFile, TRANSACTION_ID, LAST_MODIFIED);
+            .process(eomFile, TransformationMode.PUBLISH, TRANSACTION_ID, LAST_MODIFIED);
 
         String expectedBody = String.format(expectedTransformedBody, expectedMainImageUuid);
         assertThat(content.getBody(), equalToIgnoringWhiteSpace(expectedBody));

--- a/src/test/java/com/ft/methodearticlemapper/transformation/EomFileProcessorTest.java
+++ b/src/test/java/com/ft/methodearticlemapper/transformation/EomFileProcessorTest.java
@@ -26,6 +26,7 @@ import com.ft.methodearticlemapper.exception.NotWebChannelException;
 import com.ft.methodearticlemapper.exception.SourceNotEligibleForPublishException;
 import com.ft.methodearticlemapper.exception.UnsupportedEomTypeException;
 import com.ft.methodearticlemapper.exception.UnsupportedObjectTypeException;
+import com.ft.methodearticlemapper.exception.UnsupportedTransformationModeException;
 import com.ft.methodearticlemapper.exception.UntransformableMethodeContentException;
 import com.ft.methodearticlemapper.exception.WorkflowStatusNotEligibleForPublishException;
 import com.ft.methodearticlemapper.model.EomFile;
@@ -45,6 +46,7 @@ import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.TimeZone;
@@ -204,7 +206,7 @@ public class EomFileProcessorTest {
         standardEomFile = createStandardEomFile(uuid);
         standardExpectedContent = createStandardExpectedFtContent();
 
-        eomFileProcessor = new EomFileProcessor(bodyTransformer, bylineTransformer, htmlFieldProcessor, contentSourceBrandMap, API_HOST);
+        eomFileProcessor = new EomFileProcessor(EnumSet.allOf(TransformationMode.class), bodyTransformer, bylineTransformer, htmlFieldProcessor, contentSourceBrandMap, API_HOST);
     }
 
     @Test(expected = MethodeMarkedDeletedException.class)
@@ -1089,6 +1091,17 @@ public class EomFileProcessorTest {
                 eq(Maps.immutableEntry("uuid", eomFile.getUuid())),
                 eq(Maps.immutableEntry("apiHost", API_HOST)));
         assertThat(content, equalTo(expectedContent));
+    }
+
+    @Test(expected=UnsupportedTransformationModeException.class)
+    public void thatUnsupportedModeIsRejected() {
+        eomFileProcessor = new EomFileProcessor(EnumSet.of(TransformationMode.SUGGEST), bodyTransformer, bylineTransformer, htmlFieldProcessor, contentSourceBrandMap, API_HOST);
+        
+        final EomFile eomFile = new EomFile.Builder()
+                .withValuesFrom(standardEomFile)
+                .build();
+
+        eomFileProcessor.process(eomFile, TransformationMode.PUBLISH, TRANSACTION_ID, LAST_MODIFIED);
     }
 
     private void testContentPackage(final String description,

--- a/src/test/java/com/ft/methodearticlemapper/transformation/ImageSetXmlEventHandlerTest.java
+++ b/src/test/java/com/ft/methodearticlemapper/transformation/ImageSetXmlEventHandlerTest.java
@@ -50,7 +50,7 @@ public class ImageSetXmlEventHandlerTest extends BaseXMLEventHandlerTest {
         eventHandler = new ImageSetXmlEventHandler();
 
         bodyProcessingContext = new MappedDataBodyProcessingContext(
-                TEST_TID,
+                TEST_TID, TransformationMode.PUBLISH,
                 Maps.immutableEntry("uuid", ARTICLE_UUID),
                 Maps.immutableEntry("apiHost", API_HOST));
 
@@ -127,7 +127,7 @@ public class ImageSetXmlEventHandlerTest extends BaseXMLEventHandlerTest {
             imageSetStartElementTag,
             mockXmlEventReader,
             mockEventWriter,
-            new MappedDataBodyProcessingContext(TEST_TID));
+            new MappedDataBodyProcessingContext(TEST_TID, TransformationMode.PUBLISH));
 
         verifyZeroInteractions(mockEventWriter);
     }

--- a/src/test/java/com/ft/methodearticlemapper/transformation/ModalBodyProcessorTest.java
+++ b/src/test/java/com/ft/methodearticlemapper/transformation/ModalBodyProcessorTest.java
@@ -1,0 +1,61 @@
+package com.ft.methodearticlemapper.transformation;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import com.ft.bodyprocessing.BodyProcessingContext;
+import com.ft.bodyprocessing.BodyProcessor;
+
+import org.junit.Test;
+
+import java.util.EnumSet;
+
+
+public class ModalBodyProcessorTest {
+    @Test
+    public void thatWrappedProcessorIsInvokedForIncludedMode() {
+        String input = "foo";
+        String output = "bar";
+        BodyProcessor p = mock(BodyProcessor.class);
+        when(p.process(eq(input), any(BodyProcessingContext.class))).thenReturn(output);
+        
+        ModalBodyProcessor modal = new ModalBodyProcessor(p, EnumSet.of(TransformationMode.PUBLISH));
+        ModalBodyProcessingContext ctx = mock(ModalBodyProcessingContext.class);
+        when(ctx.getTransformationMode()).thenReturn(TransformationMode.PUBLISH);
+        
+        String actual = modal.process(input, ctx);
+        assertThat(actual, equalTo(output));
+    }
+    
+    @Test
+    public void thatWrappedProcessorIsNotInvokedForExcludedMode() {
+        String input = "foo";
+        String output = "bar";
+        BodyProcessor p = mock(BodyProcessor.class);
+        when(p.process(eq(input), any(BodyProcessingContext.class))).thenReturn(output);
+        
+        ModalBodyProcessor modal = new ModalBodyProcessor(p, EnumSet.of(TransformationMode.PUBLISH));
+        ModalBodyProcessingContext ctx = mock(ModalBodyProcessingContext.class);
+        when(ctx.getTransformationMode()).thenReturn(TransformationMode.PREVIEW);
+        
+        String actual = modal.process(input, ctx);
+        assertThat(actual, equalTo(input));
+        verifyZeroInteractions(p);
+    }
+    
+    @Test(expected=IllegalArgumentException.class)
+    public void thatModalBodyProcessingContextIsRequired() {
+        String input = "foo";
+        BodyProcessor p = mock(BodyProcessor.class);
+        
+        ModalBodyProcessor modal = new ModalBodyProcessor(p, EnumSet.of(TransformationMode.PUBLISH));
+        BodyProcessingContext ctx = mock(BodyProcessingContext.class);
+        
+        modal.process(input, ctx);
+    }
+}

--- a/src/test/java/com/ft/methodearticlemapper/transformation/encoding/EomFileProcessorEncodingTest.java
+++ b/src/test/java/com/ft/methodearticlemapper/transformation/encoding/EomFileProcessorEncodingTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.when;
 import com.ft.bodyprocessing.BodyProcessor;
 import com.ft.bodyprocessing.html.Html5SelfClosingTagBodyProcessor;
 import java.util.Date;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -50,7 +51,7 @@ public class EomFileProcessorEncodingTest {
         contentSourceBrandMap.put(ContentSource.FT, new Brand(FINANCIAL_TIMES_BRAND));
         contentSourceBrandMap.put(ContentSource.Reuters, new Brand(REUTERS_BRAND));
 
-        eomFileProcessor = new EomFileProcessor(bodyTransformer, bylineTransformer, htmlFieldProcessor, contentSourceBrandMap, API_HOST);
+        eomFileProcessor = new EomFileProcessor(EnumSet.allOf(TransformationMode.class), bodyTransformer, bylineTransformer, htmlFieldProcessor, contentSourceBrandMap, API_HOST);
 
         when(bylineTransformer.transform(anyString(), anyString(), eq(TransformationMode.PUBLISH))).thenReturn(TRANSFORMED_BYLINE);
     }

--- a/src/test/java/com/ft/methodearticlemapper/transformation/encoding/EomFileProcessorEncodingTest.java
+++ b/src/test/java/com/ft/methodearticlemapper/transformation/encoding/EomFileProcessorEncodingTest.java
@@ -7,6 +7,7 @@ import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.anyVararg;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
@@ -24,6 +25,7 @@ import com.ft.methodearticlemapper.methode.ContentSource;
 import com.ft.methodearticlemapper.model.EomFile;
 import com.ft.methodearticlemapper.transformation.EomFileProcessor;
 import com.ft.methodearticlemapper.transformation.FieldTransformer;
+import com.ft.methodearticlemapper.transformation.TransformationMode;
 import com.ft.uuidutils.DeriveUUID;
 import org.junit.Before;
 import org.junit.Test;
@@ -50,7 +52,7 @@ public class EomFileProcessorEncodingTest {
 
         eomFileProcessor = new EomFileProcessor(bodyTransformer, bylineTransformer, htmlFieldProcessor, contentSourceBrandMap, API_HOST);
 
-        when(bylineTransformer.transform(anyString(), anyString())).thenReturn(TRANSFORMED_BYLINE);
+        when(bylineTransformer.transform(anyString(), anyString(), eq(TransformationMode.PUBLISH))).thenReturn(TRANSFORMED_BYLINE);
     }
     
     @Test
@@ -59,7 +61,7 @@ public class EomFileProcessorEncodingTest {
                 + "to court in an apparent attempt to block the broadcast of a hit miniseries detailing her "
                 + "colourful family and business history.</p>";
         
-        when(bodyTransformer.transform(anyString(), anyString(), anyVararg()))
+        when(bodyTransformer.transform(anyString(), anyString(), eq(TransformationMode.PUBLISH), anyVararg()))
             .thenReturn(String.format("<body>%s</body>", bodyText));
         
         final UUID imageUuid = UUID.randomUUID();

--- a/src/test/java/com/ft/methodearticlemapper/transformation/encoding/EomFileProcessorEncodingTest.java
+++ b/src/test/java/com/ft/methodearticlemapper/transformation/encoding/EomFileProcessorEncodingTest.java
@@ -72,7 +72,7 @@ public class EomFileProcessorEncodingTest {
                 expectedMainImageUuid, "http://www.ft.com/ontology/content/ImageSet", bodyText);
         
         final EomFile eomFile = createStandardEomFileWithMainImage(uuid, imageUuid, "Primary size");
-        Content content = eomFileProcessor.processPublication(eomFile, TRANSACTION_ID, new Date());
+        Content content = eomFileProcessor.process(eomFile, TransformationMode.PUBLISH, TRANSACTION_ID, new Date());
         
         assertThat(String.format("body content using JVM encoding %s", System.getProperty("file.encoding")),
                 content.getBody(), equalToIgnoringWhiteSpace(expectedBody));


### PR DESCRIPTION
Makes the integrations to Kafka, document-store and concordance API optional.
- Whenever any of these integrations is configured to be disabled, the healthcheck for that integration is omitted.
- Without Kafka, the mapper only supports mapping by posting native content to its HTTP `/map` endpoint.
- Without the document-store or concordance API, the mapper can only provide mapping in `suggest` mode, which is sufficient for transforming draft content in PAC for the purpose of suggesting annotations.
