### PR TITLE
Remove new internal tags and their content: marketdata, podcast-promo.

### DIFF
--- a/src/main/java/com/ft/methodearticlemapper/transformation/MethodeBodyTransformationXMLEventHandlerRegistry.java
+++ b/src/main/java/com/ft/methodearticlemapper/transformation/MethodeBodyTransformationXMLEventHandlerRegistry.java
@@ -71,7 +71,7 @@ public class MethodeBodyTransformationXMLEventHandlerRegistry extends XMLEventHa
                 "web-background-news-header", "web-background-news-text",
                 "web-picture", "web-pull-quote-source", "web-pull-quote-text",
                 "web-skybox-picture", "web-subhead", "web-thumbnail", "xref", "xrefs",
-                "recommended"
+                "recommended", "marketdata", "podcast-promo"
         );
 
         registerStartAndEndElementEventHandler(new SimpleTransformTagXmlEventHandler("h3", "class", "ft-subhead"), "subhead");

--- a/src/test/java/com/ft/methodearticlemapper/transformation/BodyProcessingFieldTransformerFactoryTest.java
+++ b/src/test/java/com/ft/methodearticlemapper/transformation/BodyProcessingFieldTransformerFactoryTest.java
@@ -1414,6 +1414,22 @@ public class BodyProcessingFieldTransformerFactoryTest {
         checkTransformation(originalContent, transformedContent);
     }
 
+	@Test
+	public void shouldRemoveMarketDataTag(){
+		String originalContent = "<body><p>Here we are talking about some company and we're going to refer to their stock price</p><marketdata figicode=\"somefigicode\" startdata=\"some date\" live-until=\"publish date plus 1 week\"/><p>blah blah blah</p></body>";
+		String transformedContent = "<body><p>Here we are talking about some company and we're going to refer to their stock price</p><p>blah blah blah</p></body>";
+
+		checkTransformation(originalContent, transformedContent);
+	}
+
+	@Test
+	public void shouldRemovePodcastPromoTag(){
+		String originalContent = "<body><p>Here follows some audio podcast</p><podcast-promo id=\"16ec6a72-d5db-4322-96c6-314b051eb978\"><h2>This is the podcast title</h2><p>This is the podcast description</p></podcast-promo><p>blah blah blah</p></body>";
+		String transformedContent = "<body><p>Here follows some audio podcast</p><p>blah blah blah</p></body>";
+
+		checkTransformation(originalContent, transformedContent);
+	}
+
     private void checkTransformation(String originalBody, String expectedTransformedBody, Map.Entry<String, Object>... contextData) {
         checkTransformation(originalBody, expectedTransformedBody, TransformationMode.PUBLISH, contextData);
     }


### PR DESCRIPTION
Related to these issues:
- Financial-Times/upp-ftcom-lovin#14
- Financial-Times/upp-ftcom-lovin#6