### PR TITLE
Add canonicalWebUrl

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -90,7 +90,8 @@ You can find an example of a transformed article below.
     "enabled": true
   },
   "copyright": null,
-  "webUrl": null,
+  "webUrl": "https://www.ft.com/content/59b2f3b4-69c2-11e6-a0b1-d87a9fea034f",
+  "canonicalWebUrl": "https://www.ft.com/content/59b2f3b4-69c2-11e6-a0b1-d87a9fea034f",
   "publishReference": "tid_dn4kzqpoxf",
   "lastModified": "2016-08-25T06:06:23.532Z",
   "canBeSyndicated": "yes",

--- a/methode-article-mapper.yaml
+++ b/methode-article-mapper.yaml
@@ -142,6 +142,8 @@ transactionIdSource: fromTransaction
 transactionIdProperty: publishReference
 
 apiHost: "api.ft.com"
+canonicalWebUrlTemplate: "https://www.ft.com/content/%s"
+webUrlTemplate: "https://www.ft.com/content/%s"
 
 appInfo:
     systemCode: "up-mam"

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <xmlunit.version>1.5</xmlunit.version>
         <wiremock.version>1.40</wiremock.version>
         <uuid-utils.version>1.0.2</uuid-utils.version>
-        <content-model.version>0.5.1</content-model.version>
+        <content-model.version>0.6.0-rj-canonical-web-url-rc1</content-model.version>
         <!-- Plugins -->
         <findbugs.version>2.5.2</findbugs.version>
         <checkstyle.version>2.10</checkstyle.version>

--- a/src/main/java/com/ft/methodearticlemapper/MethodeArticleMapperApplication.java
+++ b/src/main/java/com/ft/methodearticlemapper/MethodeArticleMapperApplication.java
@@ -204,7 +204,9 @@ public class MethodeArticleMapperApplication extends Application<MethodeArticleM
                 new Html5SelfClosingTagBodyProcessor(),
                 processConfigurationBrands(configuration.getBrandsConfiguration()),
                 configuration.getTxIdPropertyName(),
-                configuration.getApiHost());
+                configuration.getApiHost(),
+                configuration.getWebUrlTemplate(),
+                configuration.getCanonicalWebUrlTemplate());
     }
 
     private void registerHealthChecks(Environment environment, List<AdvancedHealthCheck> advancedHealthChecks) {

--- a/src/main/java/com/ft/methodearticlemapper/configuration/MethodeArticleMapperConfiguration.java
+++ b/src/main/java/com/ft/methodearticlemapper/configuration/MethodeArticleMapperConfiguration.java
@@ -32,6 +32,8 @@ public class MethodeArticleMapperConfiguration extends Configuration implements 
     private final PropertySource txIdSource;
     private final String txIdPropertyName;
     private final String apiHost;
+    private final String webUrlTemplate;
+    private final String canonicalWebUrlTemplate;
     private final AppInfo appInfo;
     @JsonProperty
     private final GTGConfig gtgConfig= new GTGConfig();
@@ -52,6 +54,8 @@ public class MethodeArticleMapperConfiguration extends Configuration implements 
                                              @JsonProperty("transactionIdSource") PropertySource txIdSource,
                                              @JsonProperty("transactionIdProperty") String txIdPropertyName,
                                              @JsonProperty("apiHost") String apiHost,
+                                             @JsonProperty("webUrlTemplate") String webUrlTemplate,
+                                             @JsonProperty("canonicalWebUrlTemplate") String canonicalWebUrlTemplate,
                                              @JsonProperty("appInfo") AppInfo appInfo) {
 
         if ((documentStoreApiEnabled == null) || documentStoreApiEnabled.booleanValue()) {
@@ -80,6 +84,8 @@ public class MethodeArticleMapperConfiguration extends Configuration implements 
         this.txIdSource = txIdSource;
         this.txIdPropertyName = txIdPropertyName;
         this.apiHost = apiHost;
+        this.webUrlTemplate = webUrlTemplate;
+        this.canonicalWebUrlTemplate = canonicalWebUrlTemplate;
         this.appInfo = appInfo;
     }
     
@@ -148,6 +154,16 @@ public class MethodeArticleMapperConfiguration extends Configuration implements 
     @NotNull
     public String getApiHost() {
         return apiHost;
+    }
+
+    @NotNull
+    public String getCanonicalWebUrlTemplate() {
+        return canonicalWebUrlTemplate;
+    }
+
+    @NotNull
+    public String getWebUrlTemplate() {
+        return webUrlTemplate;
     }
 
     @Override

--- a/src/main/java/com/ft/methodearticlemapper/model/EomFile.java
+++ b/src/main/java/com/ft/methodearticlemapper/model/EomFile.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.net.URI;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -33,8 +32,7 @@ public class EomFile {
     private final String workflowStatus;
     private final String systemAttributes;
     private final String usageTickets;
-    private final URI webUrl;
-    
+
     private final Map<String,String> additionalProperties = new LinkedHashMap<>();
     
     public static void setAdditionalMappings(Map<String,String> additionalProperties) {
@@ -47,8 +45,7 @@ public class EomFile {
                    @JsonProperty("attributes") String attributes,
                    @JsonProperty("workflowStatus") String workflowStatus,
                    @JsonProperty("systemAttributes") String systemAttributes,
-                   @JsonProperty("usageTickets") String usageTickets,
-                   @JsonProperty("webUrl") URI webUrl) {
+                   @JsonProperty("usageTickets") String usageTickets) {
         this.uuid = uuid;
         this.type = type;
         this.value = bytes;
@@ -56,7 +53,6 @@ public class EomFile {
         this.workflowStatus = workflowStatus;
         this.systemAttributes = systemAttributes;
         this.usageTickets = usageTickets;
-        this.webUrl = webUrl;
     }
 
     public String getUuid() {
@@ -88,11 +84,6 @@ public class EomFile {
         return usageTickets;
     }
 
-
-    public URI getWebUrl() {
-        return webUrl;
-    }
-    
     @JsonAnySetter
     public void setAdditionalProperty(String name, Object value) {
         String mappedName = ADDITIONAL_PROPERTY_MAPPINGS.get(name);
@@ -114,7 +105,6 @@ public class EomFile {
         private String workflowStatus;
         private String systemAttributes;
         private String usageTickets;
-        private URI webUrl;
 
         public Builder withUuid(String uuid) {
             this.uuid = uuid;
@@ -152,11 +142,6 @@ public class EomFile {
             return this;
         }
 
-        public Builder withWebUrl(URI webUrl) {
-            this.webUrl = webUrl;
-            return this;
-        }
-
         public Builder withValuesFrom(EomFile eomFile) {
             return withUuid(eomFile.getUuid())
                     .withType(eomFile.getType())
@@ -164,12 +149,11 @@ public class EomFile {
                     .withAttributes(eomFile.getAttributes())
                     .withWorkflowStatus(eomFile.getWorkflowStatus())
                     .withSystemAttributes(eomFile.getSystemAttributes())
-                    .withUsageTickets(eomFile.getUsageTickets())
-                    .withWebUrl(eomFile.getWebUrl());
+                    .withUsageTickets(eomFile.getUsageTickets());
         }
 
         public EomFile build() {
-            return new EomFile(uuid, type, value, attributes, workflowStatus, systemAttributes, usageTickets, webUrl);
+            return new EomFile(uuid, type, value, attributes, workflowStatus, systemAttributes, usageTickets);
         }
     }
 }

--- a/src/main/java/com/ft/methodearticlemapper/transformation/EomFileProcessor.java
+++ b/src/main/java/com/ft/methodearticlemapper/transformation/EomFileProcessor.java
@@ -46,6 +46,7 @@ import javax.xml.xpath.XPathFactory;
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.net.URI;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -92,6 +93,8 @@ public class EomFileProcessor {
     private final BodyProcessor htmlFieldProcessor;
     private final String refFieldName;
     private final String apiHost;
+    private final String webUrlTemplate;
+    private final String canonicalWebUrlTemplate;
     private final Map<ContentSource, Brand> contentSourceBrandMap;
 
     public EomFileProcessor(final EnumSet<TransformationMode> supportedModes,
@@ -100,7 +103,9 @@ public class EomFileProcessor {
                             final BodyProcessor htmlFieldProcessor,
                             final Map<ContentSource, Brand> contentSourceBrandMap,
                             final String refFieldName,
-                            final String apiHost) {
+                            final String apiHost,
+                            final String webUrlTemplate,
+                            final String canonicalWebUrlTemplate) {
         this.supportedModes = supportedModes;
         this.bodyTransformer = bodyTransformer;
         this.bylineTransformer = bylineTransformer;
@@ -108,6 +113,8 @@ public class EomFileProcessor {
         this.contentSourceBrandMap = contentSourceBrandMap;
         this.refFieldName = refFieldName;
         this.apiHost = apiHost;
+        this.webUrlTemplate = webUrlTemplate;
+        this.canonicalWebUrlTemplate = canonicalWebUrlTemplate;
     }
 
     private static Date toDate(String dateString, String format) {
@@ -189,6 +196,8 @@ public class EomFileProcessor {
         final AlternativeStandfirsts alternativeStandfirsts = buildAlternativeStandfirsts(xpath, value);
 
         final String workFolder = xpath.evaluate(EomFile.WORK_FOLDER_SYSTEM_ATTRIBUTE_XPATH, eomFile.getSystemAttributes());
+        final URI webUrl = URI.create(String.format(this.webUrlTemplate, uuid));
+        final URI canonicalWebUrl = URI.create(String.format(this.canonicalWebUrlTemplate, uuid));
 
         return Content.builder()
                 .withUuid(uuid)
@@ -204,7 +213,6 @@ public class EomFileProcessor {
                 .withIdentifiers(ImmutableSortedSet.of(new Identifier(METHODE, uuid.toString())))
                 .withComments(Comments.builder().withEnabled(discussionEnabled).build())
                 .withStandout(buildStandoutSection(xpath, attributes))
-                .withWebUrl(eomFile.getWebUrl())
                 .withTransactionId(refFieldName, transactionId)
                 .withLastModified(lastModified)
                 .withCanBeSyndicated(canBeSyndicated)
@@ -216,6 +224,8 @@ public class EomFileProcessor {
                 .withCanBeDistributed(canBeDistributed)
                 .withAlternativeStandfirsts(alternativeStandfirsts)
                 .withEditorialDesk(workFolder)
+                .withWebUrl(webUrl)
+                .withCanonicalWebUrl(canonicalWebUrl)
                 .build();
     }
 

--- a/src/main/java/com/ft/methodearticlemapper/transformation/ParsedEomFile.java
+++ b/src/main/java/com/ft/methodearticlemapper/transformation/ParsedEomFile.java
@@ -3,7 +3,6 @@ package com.ft.methodearticlemapper.transformation;
 import com.ft.methodearticlemapper.methode.ContentSource;
 import org.w3c.dom.Document;
 
-import java.net.URI;
 import java.util.UUID;
 
 public class ParsedEomFile {
@@ -12,18 +11,16 @@ public class ParsedEomFile {
     private final Document systemAttributes;
     private final Document value;
     private final String body;
-    private final URI webUrl;
     private ContentSource contentSource;
 
     public ParsedEomFile(UUID uuid, Document value, String body, Document attributesDocument,
-                         Document systemAttributes, URI webUrl,
+                         Document systemAttributes,
                          ContentSource contentSource) {
         this.uuid = uuid;
         this.value = value;
         this.body = body;
         this.attributesDocument = attributesDocument;
         this.systemAttributes = systemAttributes;
-        this.webUrl = webUrl;
         this.contentSource = contentSource;
     }
 
@@ -45,10 +42,6 @@ public class ParsedEomFile {
 
     public Document getSystemAttributes() {
         return systemAttributes;
-    }
-
-    public URI getWebUrl() {
-        return webUrl;
     }
 
     public ContentSource getContentSource() {

--- a/src/main/java/com/ft/methodearticlemapper/transformation/eligibility/PublishEligibilityChecker.java
+++ b/src/main/java/com/ft/methodearticlemapper/transformation/eligibility/PublishEligibilityChecker.java
@@ -148,7 +148,7 @@ public abstract class PublishEligibilityChecker {
         checkBody();
 
         return new ParsedEomFile(uuid, eomFileDocument, rawBody,
-            attributesDocument, systemAttributesDocument, eomFile.getWebUrl(), contentSource);
+            attributesDocument, systemAttributesDocument, contentSource);
     }
 
     public final ParsedEomFile getEligibleContentForPreview()
@@ -166,7 +166,7 @@ public abstract class PublishEligibilityChecker {
         ContentSource contentSource = processSourceForPreview();
 
         return new ParsedEomFile(uuid, eomFileDocument, rawBody,
-            attributesDocument, systemAttributesDocument ,eomFile.getWebUrl(), contentSource);
+            attributesDocument, systemAttributesDocument, contentSource);
     }
 
     private final void parseEomFile()

--- a/src/test/java/com/ft/methodearticlemapper/model/EomFileTest.java
+++ b/src/test/java/com/ft/methodearticlemapper/model/EomFileTest.java
@@ -1,7 +1,6 @@
 package com.ft.methodearticlemapper.model;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -54,7 +53,6 @@ public class EomFileTest {
         assertThat(actual.getSystemAttributes(), equalTo(SYS_ATTRS));
         assertThat(actual.getWorkflowStatus(), equalTo(WEB_READY));
         assertThat(actual.getUsageTickets(), equalTo(TICKETS));
-        assertThat(actual.getWebUrl(), nullValue());
         assertThat(actual.getAdditionalProperties(), equalTo(Collections.emptyMap()));
     }
     
@@ -86,8 +84,7 @@ public class EomFileTest {
         assertThat(actual.getSystemAttributes(), equalTo(SYS_ATTRS));
         assertThat(actual.getWorkflowStatus(), equalTo(WEB_READY));
         assertThat(actual.getUsageTickets(), equalTo(TICKETS));
-        assertThat(actual.getWebUrl(), nullValue());
-        
+
         Map<String,String> expectedAdditionalProperties = new HashMap<>();
         expectedAdditionalProperties.put("lastModified", lastModified);
         expectedAdditionalProperties.put("publishReference", publishReference);
@@ -123,8 +120,7 @@ public class EomFileTest {
         assertThat(actual.getSystemAttributes(), equalTo(SYS_ATTRS));
         assertThat(actual.getWorkflowStatus(), equalTo(WEB_READY));
         assertThat(actual.getUsageTickets(), equalTo(TICKETS));
-        assertThat(actual.getWebUrl(), nullValue());
-        
+
         Map<String,String> expectedAdditionalProperties = new HashMap<>();
         expectedAdditionalProperties.put("lastModified", lastModified);
         expectedAdditionalProperties.put("publishReference", publishReference);
@@ -160,8 +156,7 @@ public class EomFileTest {
         assertThat(actual.getSystemAttributes(), equalTo(SYS_ATTRS));
         assertThat(actual.getWorkflowStatus(), equalTo(WEB_READY));
         assertThat(actual.getUsageTickets(), equalTo(TICKETS));
-        assertThat(actual.getWebUrl(), nullValue());
-        
+
         Map<String,String> expectedAdditionalProperties = new HashMap<>();
         expectedAdditionalProperties.put("lastModified", lastModified);
         expectedAdditionalProperties.put("publishReference", publishReference);

--- a/src/test/java/com/ft/methodearticlemapper/resources/ArticlePreviewTransformationTest.java
+++ b/src/test/java/com/ft/methodearticlemapper/resources/ArticlePreviewTransformationTest.java
@@ -44,6 +44,8 @@ public class ArticlePreviewTransformationTest {
     private static final String INVALID_EOM_FILE_TYPE = "NOT_COMPOUND_STORY";
     private static final String PUBLISH_REF = "publishReference";
     private static final String API_HOST = "test.api.ft.com";
+    private static final String WEB_URL_TEMPLATE = "https://www.ft.com/content/%s";
+    private static final String CANONICAL_WEB_URL_TEMPLATE = "https://www.ft.com/content/%s";
     private FieldTransformer bodyTransformer = mock(FieldTransformer.class);
     private FieldTransformer bylineTransformer = mock(FieldTransformer.class);
     private BodyProcessor htmlFieldProcessor = spy(new Html5SelfClosingTagBodyProcessor());
@@ -54,12 +56,15 @@ public class ArticlePreviewTransformationTest {
     private PostContentToTransformResource postContentToTransformResource;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         Map<ContentSource, Brand> contentSourceBrandMap = new HashMap<>();
         contentSourceBrandMap.put(ContentSource.FT, new Brand(ARBITRARY_BRAND));
 
-        eomFileProcessor = new EomFileProcessor(EnumSet.allOf(TransformationMode.class), bodyTransformer, bylineTransformer, htmlFieldProcessor, contentSourceBrandMap, PUBLISH_REF, API_HOST);
-        postContentToTransformResource = new PostContentToTransformResource(eomFileProcessor, PropertySource.fromTransaction, PropertySource.fromTransaction, PUBLISH_REF);
+        eomFileProcessor = new EomFileProcessor(EnumSet.allOf(TransformationMode.class), bodyTransformer,
+                bylineTransformer, htmlFieldProcessor, contentSourceBrandMap, PUBLISH_REF, API_HOST,
+                WEB_URL_TEMPLATE, CANONICAL_WEB_URL_TEMPLATE);
+        postContentToTransformResource = new PostContentToTransformResource(eomFileProcessor,
+                PropertySource.fromTransaction, PropertySource.fromTransaction, PUBLISH_REF);
 
         MDC.put("transaction_id", "transaction_id=" + TRANSACTION_ID);
     }
@@ -102,6 +107,6 @@ public class ArticlePreviewTransformationTest {
                 VALUE_PROPERTY.getBytes(),
                 ATTRIBUTES_PROPERTY,
                 WORKFLOW_STATUS[0],
-                SYSTEM_ATTRIBUTES_PROPERTY, null, null);
+                SYSTEM_ATTRIBUTES_PROPERTY, null);
     }
 }

--- a/src/test/java/com/ft/methodearticlemapper/transformation/EomFileProcessorTest.java
+++ b/src/test/java/com/ft/methodearticlemapper/transformation/EomFileProcessorTest.java
@@ -70,6 +70,7 @@ import static org.mockito.AdditionalAnswers.returnsFirstArg;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.anyVararg;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -955,6 +956,14 @@ public class EomFileProcessorTest {
 
         Content content = eomFileProcessor.process(eomFile, TransformationMode.PUBLISH, TRANSACTION_ID, LAST_MODIFIED);
         assertThat(content.getWebUrl(), is(equalTo(webUrl)));
+    }
+
+    @Test
+    public void thatCanonicalWebUrlIsNull() {
+        final EomFile eomFile = createStandardEomFile(uuid);
+
+        Content content = eomFileProcessor.process(eomFile, TransformationMode.PUBLISH, TRANSACTION_ID, LAST_MODIFIED);
+        assertThat(content.getCanonicalWebUrl(), is(nullValue()));
     }
 
     @Test

--- a/src/test/java/com/ft/methodearticlemapper/transformation/EomFileProcessorTest.java
+++ b/src/test/java/com/ft/methodearticlemapper/transformation/EomFileProcessorTest.java
@@ -70,7 +70,6 @@ import static org.mockito.AdditionalAnswers.returnsFirstArg;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.anyVararg;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;

--- a/src/test/java/com/ft/methodearticlemapper/transformation/encoding/EomFileProcessorEncodingTest.java
+++ b/src/test/java/com/ft/methodearticlemapper/transformation/encoding/EomFileProcessorEncodingTest.java
@@ -37,6 +37,8 @@ public class EomFileProcessorEncodingTest {
     private static final String TRANSACTION_ID = "tid_test";
     private static final String PUBLISH_REF = "publishReference";
     private static final String API_HOST = "test.api.ft.com";
+    private static final String WEB_URL_TEMPLATE = "https://www.ft.com/content/%s";
+    private static final String CANONICAL_WEB_URL_TEMPLATE = "https://www.ft.com/content/%s";
     
     private FieldTransformer bodyTransformer = mock(FieldTransformer.class);
     private FieldTransformer bylineTransformer = mock(FieldTransformer.class);
@@ -47,12 +49,14 @@ public class EomFileProcessorEncodingTest {
     private EomFileProcessor eomFileProcessor;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         Map<ContentSource, Brand> contentSourceBrandMap = new HashMap<>();
         contentSourceBrandMap.put(ContentSource.FT, new Brand(FINANCIAL_TIMES_BRAND));
         contentSourceBrandMap.put(ContentSource.Reuters, new Brand(REUTERS_BRAND));
 
-        eomFileProcessor = new EomFileProcessor(EnumSet.allOf(TransformationMode.class), bodyTransformer, bylineTransformer, htmlFieldProcessor, contentSourceBrandMap, PUBLISH_REF, API_HOST);
+        eomFileProcessor = new EomFileProcessor(EnumSet.allOf(TransformationMode.class), bodyTransformer,
+                bylineTransformer, htmlFieldProcessor, contentSourceBrandMap, PUBLISH_REF, API_HOST,
+                WEB_URL_TEMPLATE, CANONICAL_WEB_URL_TEMPLATE);
 
         when(bylineTransformer.transform(anyString(), anyString(), eq(TransformationMode.PUBLISH))).thenReturn(TRANSFORMED_BYLINE);
     }


### PR DESCRIPTION
`webUrl` is now set based on a configurable template instead of being retrieved from the eomFile
`canonicalWebUrl` has been added and is set based on a configurable template

https://github.com/Financial-Times/upp-ftcom-lovin/issues/16