### PR TITLE
Fix: Whitespace stripped out between links and parentheses

### DIFF
--- a/src/main/java/com/ft/methodearticlemapper/transformation/MethodeLinksBodyProcessor.java
+++ b/src/main/java/com/ft/methodearticlemapper/transformation/MethodeLinksBodyProcessor.java
@@ -72,7 +72,7 @@ public class MethodeLinksBodyProcessor implements BodyProcessor {
     private static final String STRING_ENDS_WITH_WHITESPACE_REGEX = ".*\\s+$";
     private static final Pattern STRING_ENDS_WITH_WHITESPACE_REGEX_PATTERN = Pattern.compile(STRING_ENDS_WITH_WHITESPACE_REGEX);
     private static final String STRING_STARTS_WITH_WHITESPACE_REGEX = "^\\s+";
-    private static final String STRING_STARTS_WITH_PUNCTUATION_REGEX = "^\\p{Punct}+.*";
+    private static final String STRING_STARTS_WITH_PUNCTUATION_REGEX = "^(\\p{Pc}|\\p{Pd}|\\p{Pe}|\\p{Pf}|\\p{Po})+.*";
     private static final Pattern STRING_STARTS_WITH_PUNCTUATION_REGEX_PATTERN = Pattern.compile(STRING_STARTS_WITH_PUNCTUATION_REGEX);
     private static final String STRING_ENDS_WITH_PUNCTUATION_REGEX = "\\p{Punct}+$";
     private static final Pattern STRING_ENDS_WITH_PUNCTUATION_REGEX_PATTERN = Pattern.compile(STRING_ENDS_WITH_PUNCTUATION_REGEX);

--- a/src/test/java/com/ft/methodearticlemapper/transformation/MethodeLinksBodyProcessorTest.java
+++ b/src/test/java/com/ft/methodearticlemapper/transformation/MethodeLinksBodyProcessorTest.java
@@ -402,6 +402,19 @@ public class MethodeLinksBodyProcessorTest {
 	}
 
 	@Test
+	public void thatWhitespaceNotRemovedWhenParenthesisPunctuation() {
+		when(clientResponse.getStatus()).thenReturn(200);
+		when(clientResponse.getEntity(String.class)).thenReturn("[{\"uuid\":\"" + uuid + "\", \"type\": \"Article\"}]");
+
+		String body = "<body><p><a href=\"" + uuid + "\">link text</a>  (some details)</p></body>";
+		String expectedBody = "<body><p><content id=\"" + uuid + "\" type=\"" + MethodeLinksBodyProcessor.BASE_CONTENT_TYPE + "Article\">link text</content> (some details)</p></body>";
+		
+		String processedBody = bodyProcessor.process(body, new DefaultTransactionIdBodyProcessingContext(TRANSACTION_ID));
+
+		assertThat(processedBody, is(identicalXmlTo(expectedBody)));
+	}
+
+	@Test
 	public void thatWhitespaceFromLinkTextAreRemoved() {
 		when(clientResponse.getStatus()).thenReturn(200);
 		when(clientResponse.getEntity(String.class)).thenReturn("[{\"uuid\":\"" + uuid + "\", \"type\": \"Article\"}]");


### PR DESCRIPTION
https://github.com/Financial-Times/upp-ftcom-lovin/issues/46